### PR TITLE
continue add exception mechanism

### DIFF
--- a/source/big_core/big_core_pkg.vh
+++ b/source/big_core/big_core_pkg.vh
@@ -176,9 +176,9 @@ typedef struct packed {
 } t_csr_hw_updt;
 
 typedef struct packed {
-    logic        InterruptJumpQ102H;
+    logic        InterruptJumpEnQ102H;
     logic [31:0] InterruptJumpAddressQ102H;
-    logic        InteruptReturnQ102H;
+    logic        InteruptReturnEnQ102H;
     logic [31:0] InteruptReturnAddressQ102H; 
 } t_csr_pc_update;
 

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -291,17 +291,17 @@ always_comb begin
 end
 
 // Update program counter
-logic  InterruptAcknowladge;
-assign InterruptAcknowladge = (CsrHwUpdtQ102H.illegal_instruction) || (CsrHwUpdtQ102H.misaligned_access) || (CsrHwUpdtQ102H.illegal_csr_access) || (CsrHwUpdtQ102H.breakpoint) || (CsrHwUpdtQ102H.external_interrupt) || (CsrHwUpdtQ102H.timer_interrupt);
+logic  BeginInterrupt;
+assign BeginInterrupt = (CsrHwUpdtQ102H.illegal_instruction) || (CsrHwUpdtQ102H.misaligned_access) || (CsrHwUpdtQ102H.illegal_csr_access) || (CsrHwUpdtQ102H.breakpoint) || (CsrHwUpdtQ102H.external_interrupt) || (CsrHwUpdtQ102H.timer_interrupt);
 
-//assign CsrPcUpdateQ102H.InterruptJumpQ102H         = InterruptAcknowladge;
+//assign CsrPcUpdateQ102H.InterruptJumpEnQ102H       = BeginInterrupt;
 //assign CsrPcUpdateQ102H.InterruptJumpAddressQ102H  = next_csr.csr_mtvec;
-//assign CsrPcUpdateQ102H.InteruptReturnQ102H        = CsrHwUpdtQ102H.Mret;
+//assign CsrPcUpdateQ102H.InteruptReturnEnQ102H      = CsrHwUpdtQ102H.Mret;
 //assign CsrPcUpdateQ102H.InteruptReturnAddressQ102H = next_csr.csr_mepc;
 
-assign CsrPcUpdateQ102H.InterruptJumpQ102H         = 0;
+assign CsrPcUpdateQ102H.InterruptJumpEnQ102H         = 0;
 assign CsrPcUpdateQ102H.InterruptJumpAddressQ102H  = 0;
-assign CsrPcUpdateQ102H.InteruptReturnQ102H        = 0;
+assign CsrPcUpdateQ102H.InteruptReturnEnQ102H        = 0;
 assign CsrPcUpdateQ102H.InteruptReturnAddressQ102H = 0;
 
 //assign MePc = csr.csr_mepc;

--- a/source/core_rrv/core_rrv_if.sv
+++ b/source/core_rrv/core_rrv_if.sv
@@ -30,8 +30,8 @@ logic [31:0] PcPlus4Q100H;
 logic [31:0] NextPcQnnnH;
 assign PcPlus4Q100H = PcQ100H + 3'h4;
 
-assign NextPcQnnnH = CsrPcUpdateQ102H.InterruptJumpQ102H  ? CsrPcUpdateQ102H.InterruptJumpAddressQ102H         :
-                     CsrPcUpdateQ102H.InteruptReturnQ102H ? CsrPcUpdateQ102H.InteruptReturnAddressQ102H + 3'h4 :
+assign NextPcQnnnH = CsrPcUpdateQ102H.InterruptJumpEnQ102H  ? CsrPcUpdateQ102H.InterruptJumpAddressQ102H         :
+                     CsrPcUpdateQ102H.InteruptReturnEnQ102H ? CsrPcUpdateQ102H.InteruptReturnAddressQ102H + 3'h4 :
                      Ctrl.SelNextPcAluOutQ102H            ? AluOutQ102H                                        :
                                                             PcPlus4Q100H;
 //assign NextPcQnnnH  = Ctrl.SelNextPcAluOutQ102H ? AluOutQ102H : PcPlus4Q100H;

--- a/source/core_rrv/illegal_instructions.sv
+++ b/source/core_rrv/illegal_instructions.sv
@@ -1,0 +1,45 @@
+//-----------------------------------------------------------------------------
+// Title            : illegal_instructions
+// Project          : fpga_mafia
+//-----------------------------------------------------------------------------
+// File             : illegal_instructions.sv
+// Original Author  : 
+// Code Owner       : Amichai Ben-David
+// Adviser          : Amichai Ben-David
+// Created          : 12/2023
+// Description      : List of possible illigal instructions scenarios in RV32I
+//-----------------------------------------------------------------------------
+
+logic PreIllegalInstructionEn;
+
+logic OpcodeNotMatchRV32I;
+logic Funct3OrFunct7NotMatch;
+
+always_comb begin
+    Funct3OrFunct7NotMatch = 0;
+    case (OpcodeQ101H)
+        //funct7 do not match the instruction  
+        R_OP: if (((CtrlQ101H.AluOp == ADD || CtrlQ101H.AluOp == SLL || CtrlQ101H.AluOp == SLT || CtrlQ101H.AluOp == SLTU || CtrlQ101H.AluOp == XOR || CtrlQ101H.AluOp == SRL || CtrlQ101H.AluOp == OR  || CtrlQ101H.AluOp == AND) && Funct7Q101H != 7'b0000000)
+                 || ((CtrlQ101H.AluOp == SUB || CtrlQ101H.AluOp == SRA) && Funct7Q101H != 7'b0100000)) Funct3OrFunct7NotMatch = 1;
+        //funct7 do not match for slli, srli, srai  
+        I_OP: if ((Funct3Q101H == 3'b001 && Funct7Q101H != 7'b0000000) || (Funct3Q101H == 3'b101 && !(Funct7Q101H == 7'b0000000 || Funct7Q101H == 7'b0100000))) Funct3OrFunct7NotMatch = 1; 
+        //undefined funct3 for store instructions         
+        STORE: if (!(Funct3Q101H == 3'b000 || Funct3Q101H == 3'b001 || Funct3Q101H == 3'b010)) Funct3OrFunct7NotMatch = 1; 
+        //undefined funct3 for load instructions 
+        LOAD: if (Funct3Q101H == 3'b011 || Funct3Q101H == 3'b110 || Funct3Q101H == 3'b111) Funct3OrFunct7NotMatch = 1;
+        //undefined funct3 for Branch instructions
+        BRANCH: if (Funct3Q101H == 3'b010 || Funct3Q101H == 3'b011) Funct3OrFunct7NotMatch = 1;
+        //undefined funct3 for JALR instructions
+        JALR: if (Funct3Q101H != 3'b000)  Funct3OrFunct7NotMatch = 1; 
+    endcase
+end
+
+always_comb begin
+    OpcodeNotMatchRV32I = 0;
+    if (!(OpcodeQ101H == R_OP || OpcodeQ101H == I_OP || OpcodeQ101H == STORE || OpcodeQ101H == LOAD || OpcodeQ101H == BRANCH || OpcodeQ101H == JALR)
+       || (OpcodeQ101H == LUI || OpcodeQ101H == AUIPC || OpcodeQ101H == JAL || OpcodeQ101H == FENCE || OpcodeQ101H == SYSCAL))  OpcodeNotMatchRV32I = 1; 
+end
+
+assign  PreIllegalInstructionEn = Funct3OrFunct7NotMatch || OpcodeNotMatchRV32I;
+
+


### PR DESCRIPTION
### updates
- Add `illegal_instruction.sv` file to include possible scenarios of illegal instructions
- illegal instruction detection mechanism at `core_rrv.sv`

### FIXME
- solve loop failure in illegal instruction detection mechanism at `core_rrv.sv` while inserting NOP. commented at that point to pass  PR
- solve conflict between `MAFIA_EN_RST_DFF(CsrHwUpdtQ102H, CsrHwUpdtQ101H, Clock, ReadyQ102H, Rst )` and `assign CsrHwUpdtQ102H.ValidInstQ105H = ValidInstQ105H`. Commented at that point to pass PR. Both located in `core_rrv_ctrl.sv`