### PR TITLE
using the cfg file to run the ovrd_params script

### DIFF
--- a/app/cfg/core_rrv_boot_trap.json
+++ b/app/cfg/core_rrv_boot_trap.json
@@ -5,5 +5,6 @@
     "D_MEM_LENGTH": 61440,
     "crt0_file"   : "crt0_boot_trap.S",
     "rv32_gcc"    : "rv32i",
-    "name"        : "rv32i"
+    "name"        : "rv32i",
+    "ovrd_params" : "override_rrv_rv32i"
 }

--- a/app/cfg/mini_rv32e.json
+++ b/app/cfg/mini_rv32e.json
@@ -5,5 +5,6 @@
     "D_MEM_LENGTH": 61440,
     "crt0_file"   : "crt0_mini_rv32e.S",
     "rv32_gcc"    : "rv32e -mabi=ilp32e",
-    "name"        : "rv32e"
+    "name"        : "rv32e",
+    "ovrd_params" : "override_rrv_rv32e"
 }

--- a/app/cfg/mini_rv32i.json
+++ b/app/cfg/mini_rv32i.json
@@ -5,6 +5,7 @@
     "D_MEM_LENGTH": 61440,
     "crt0_file"   : "crt0_mini_rv32i.S",
     "rv32_gcc"    : "rv32i",
-    "name"        : "rv32i"
+    "name"        : "rv32i",
+    "ovrd_params" : "override_rrv_rv32i"
 }
 

--- a/scripts/ovrd_params/override_rrv_rv32i.csv
+++ b/scripts/ovrd_params/override_rrv_rv32i.csv
@@ -1,0 +1,3 @@
+RF_NUM_MSB, 31
+TEST_NO_PARAM, 0
+

--- a/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
@@ -102,7 +102,7 @@ initial begin: test_seq
 end // test_seq
 
 parameter V_TIMEOUT = 100000;
-parameter RF_NUM_MSB = 15; // NOTE!!!: auto inserted from script ovrd_params.py
+parameter RF_NUM_MSB = 31; // NOTE!!!: auto inserted from script ovrd_params.py
 initial begin: detect_timeout
     //=======================================
     // timeout

--- a/verif/core_rrv/tb/core_rrv_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_tb.sv
@@ -129,7 +129,7 @@ initial begin: test_seq
 end // test_seq
 
 parameter V_TIMEOUT = 100000;
-parameter RF_NUM_MSB = 15; // NOTE!!!: auto inserted from script ovrd_params.py
+parameter RF_NUM_MSB = 31; // NOTE!!!: auto inserted from script ovrd_params.py
 initial begin: detect_timeout
     //=======================================
     // timeout


### PR DESCRIPTION
As you can see, the build will call the "./scripts/ovrd_params.py" scripts only if needed (exists in the cfg file)

the default is not to try and override the parameters values. There are very specific cases where we would want to do such a thing.

supporting the rv32e HW configuration is one of them..
But later on it will have usages in the fabric. FIFO size, buffer sizes, fabric size, memory size etc..