### PR TITLE
core_rrv fixes:

### DIFF
--- a/.github/workflows/mafia_sanity.yml
+++ b/.github/workflows/mafia_sanity.yml
@@ -21,7 +21,7 @@ jobs:
         run:  python build.py -dut core_rrv -regress rv32i_level0 -app -hw -sim -keep_going
       
       - name: CORE_RRV - rv32i_level0_cfg_intrpt -cfg core_rrv_boot_trap
-        run:  python build.py -dut core_rrv -cfg core_rrv_boot_trap -regress rv32i_level0_cfg_intrpt -app -hw -sim -keep_going
+        run:  python build.py -dut core_rrv -top core_rrv_no_ref_tb -cfg core_rrv_boot_trap -regress rv32i_level0_cfg_intrpt -app -hw -sim -keep_going
       
       - name: MINI_CORE at rv32e mode
         run:  python build.py -dut 'mini_core' -regress rv32e_level0 -cfg mini_rv32e -app -hw -sim -keep_going

--- a/source/core_rrv/core_rrv_ctrl.sv
+++ b/source/core_rrv/core_rrv_ctrl.sv
@@ -127,20 +127,12 @@ assign flushQ102H = IndirectBranchQ102H                         ||
                     TimerInterruptQ102H;
 `MAFIA_EN_DFF(flushQ103H , flushQ102H   , Clock , ReadyQ103H)
 
-assign InstructionQ101H = flushQ102H                  ? NOP :
-                          flushQ103H                  ? NOP :
-                          TimerInterruptQ101H        ? NOP :
-                          PreIllegalInstructionQ101H  ? NOP :
-                          LoadHzrd1DetectQ101H        ? NOP :
-                          LoadHzrd2DetectQ101H        ? NOP : 
-                                                        PreInstructionQ101H;
-assign PreValidInstQ101H = flushQ102H                 ? 1'b0 : 
-                           flushQ103H                 ? 1'b0 :   
-                           TimerInterruptQ101H       ? 1'b0 :
-                           PreIllegalInstructionQ101H ? 1'b0 :
-                           LoadHzrd1DetectQ101H       ? 1'b0 :  
-                           LoadHzrd2DetectQ101H       ? 1'b0 : 
-                                                        1'b1 ;
+logic InsertNopQ101H;
+assign InsertNopQ101H = flushQ102H           || flushQ103H                 || //
+                        TimerInterruptQ101H  || PreIllegalInstructionQ101H || 
+                        LoadHzrd1DetectQ101H || LoadHzrd2DetectQ101H;
+assign InstructionQ101H = InsertNopQ101H  ? NOP  :  PreInstructionQ101H;
+assign PreValidInstQ101H = InsertNopQ101H ? 1'b0 :  1'b1 ;
 
 // End Load and Ctrl hazard detection
 assign OpcodeQ101H                = t_opcode'(InstructionQ101H[6:0]);

--- a/verif/core_rrv/regress/rv32i_level0_cfg_intrpt
+++ b/verif/core_rrv/regress/rv32i_level0_cfg_intrpt
@@ -1,1 +1,2 @@
 alive_illegal.c     -gRF_NUM_MSB=31
+bubblesort_with_timer.c -gRF_NUM_MSB=31

--- a/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
@@ -18,7 +18,7 @@
 
 `include "macros.sv"
 
-module core_rrv_tb  ;
+module core_rrv_no_ref_tb  ;
 import core_rrv_pkg::*;
 logic        Clk;
 logic        Rst;
@@ -33,13 +33,13 @@ logic [31:0] DMemRdRspData;
 logic  [7:0] IMem     [I_MEM_SIZE + I_MEM_OFFSET- 1 : I_MEM_OFFSET];
 logic  [7:0] DMem     [D_MEM_SIZE + D_MEM_OFFSET - 1 : D_MEM_OFFSET];
 
+string test_name;
 `include "core_rrv_pmon_tasks.vh"
 
 // VGA interface outputs
 t_vga_out   vga_out;
 logic inDisplayArea;
 
-string test_name;
 
 // ========================
 // clock gen
@@ -113,6 +113,20 @@ initial begin: detect_timeout
     $finish;
 end
 
+logic        InFabricValidQ503H  ; 
+logic        OutFabricValidQ505H ;
+t_tile_trans InFabricQ503H ; 
+t_tile_trans OutFabricQ505H ;
+assign InFabricValidQ503H = 1'b0;
+assign InFabricQ503H.address               = '0;
+assign InFabricQ503H.opcode                = RD_RSP;
+assign InFabricQ503H.data                  = '0;
+assign InFabricQ503H.requestor_id          = '0;
+assign InFabricQ503H.next_tile_fifo_arb_id = NULL_CARDINAL;
+
+
+t_tile_id local_tile_id;
+assign  local_tile_id = 8'h2_2;
 core_rrv_top
 #( .RF_NUM_MSB(RF_NUM_MSB) )    
 core_rrv_top (

--- a/verif/core_rrv/tb/core_rrv_verif_list.f
+++ b/verif/core_rrv/tb/core_rrv_verif_list.f
@@ -2,3 +2,4 @@
 ../../../verif/rv32i_ref/tb/rv32i_ref_pkg.sv
 ../../../verif/rv32i_ref/tb/rv32i_ref.sv
 ../../../verif/core_rrv/tb/core_rrv_no_ref_tb.sv
+../../../verif/core_rrv/tb/core_rrv_tb.sv


### PR DESCRIPTION
- update f file to have both versions of core_rrv_tb and core_rrv_no_ref_tb
- fix sanity to use correct top for each type of test
- refactor the no insertion in core_rrv RTL
- add new tests to level0_intrp
- clean warnings from the core_rrv_no_ref_tb