### PR TITLE
refactor TimerInterruptQ101 in ctrl

### DIFF
--- a/source/core_rrv/core_rrv_ctrl.sv
+++ b/source/core_rrv/core_rrv_ctrl.sv
@@ -188,7 +188,8 @@ logic ebreak_was_calledQ101H;
 logic ecall_was_calledQ101H;
 logic mret_was_calledQ101H;
 //                                                       {funct7, rs2, rs1, funct3, rd, opcode}
-assign ebreak_was_calledQ101H = (InstructionQ101H == 32'b0000000_00001_00000_000_00000_1110011 && PreValidInstQ101H) ;
+//assign ebreak_was_calledQ101H = (InstructionQ101H == 32'b0000000_00001_00000_000_00000_1110011 && PreValidInstQ101H) ;
+assign ebreak_was_calledQ101H = (InstructionQ101H == 32'b0000000_00001_00000_000_00000_1110011);
 assign ecall_was_calledQ101H  = (InstructionQ101H == 32'b0000000_00000_00000_000_00000_1110011);
 assign mret_was_calledQ101H   = (InstructionQ101H == 32'b0011000_00010_00000_000_00000_1110011);
 // Update Interrupts CSR and flow control

--- a/source/core_rrv/core_rrv_ctrl.sv
+++ b/source/core_rrv/core_rrv_ctrl.sv
@@ -91,9 +91,19 @@ assign PreRegSrc2Q101H           = PreInstructionQ101H[24:20];
 logic IllegalInstructionQ101H;
 assign IllegalInstructionQ101H = (PreIllegalInstructionQ101H) && ! (flushQ102H || flushQ103H);
 
+logic PreTimerInterruptQ101H;
+assign PreTimerInterruptQ101H = (CsrTimerInterruptQ102H.csr_custom_mtime == CsrTimerInterruptQ102H.csr_custom_mtimecmp);
+
+logic CsrMstatusMieBit, CsrMieMieBit, TimerInterruptEnable;
+assign CsrMstatusMieBit = CsrTimerInterruptQ102H.csr_mstatus[3];
+assign CsrMieMieBit     = CsrTimerInterruptQ102H.csr_mie[7];
+assign TimerInterruptEnable = CsrMstatusMieBit & CsrMieMieBit;
+
 logic TimerInterruptQ101H;
-assign TimerInterruptQ101H = (CsrTimerInterruptQ102H.csr_mstatus[3] && CsrTimerInterruptQ102H.csr_mie[7]) &&
-                              (CsrTimerInterruptQ102H.csr_custom_mtime == CsrTimerInterruptQ102H.csr_custom_mtimecmp);
+//assign TimerInterruptQ101H = (CsrTimerInterruptQ102H.csr_mstatus[3] && CsrTimerInterruptQ102H.csr_mie[7]) &&
+//                              (CsrTimerInterruptQ102H.csr_custom_mtime == CsrTimerInterruptQ102H.csr_custom_mtimecmp);
+
+assign TimerInterruptQ101H = PreTimerInterruptQ101H & TimerInterruptEnable;
 
 logic LoadHazardValidRegSrc2Q101H;
 logic RegDstQ102MatchRegSrc1Q101H;


### PR DESCRIPTION
```
logic PreTimerInterruptQ101H;
assign PreTimerInterruptQ101H = (CsrTimerInterruptQ102H.csr_custom_mtime == CsrTimerInterruptQ102H.csr_custom_mtimecmp);

logic CsrMstatusMieBit, CsrMieMieBit, TimerInterruptEnable;
assign CsrMstatusMieBit = CsrTimerInterruptQ102H.csr_mstatus[3];
assign CsrMieMieBit     = CsrTimerInterruptQ102H.csr_mie[7];
assign TimerInterruptEnable = CsrMstatusMieBit & CsrMieMieBit;

logic TimerInterruptQ101H;

assign TimerInterruptQ101H = PreTimerInterruptQ101H & TimerInterruptEnable;
```

I left the `==`  instead of `<=` as we discussed because it gives us an interrupt at two cycles and caused `test ended with timeout`. The reason for that is the interrupt enable bit do not disabled immediately. We will fix that after we will meet so I leave it as is for know.

I red carefully all the changes and comments you did in PR#459.
I removed the `PreValidInstQ101H` from ebreak and it works, probably it was something else. I cant find now the exact cause that made that failure