### PR TITLE
fix issues we talked about csr 

### DIFF
--- a/app/defines/interrupt_handler.h
+++ b/app/defines/interrupt_handler.h
@@ -5,7 +5,7 @@
 // RISCV mcause exceptions defines for detection: 
 #define ILLEGAL_INSTRUCTION_EXCEPTION     0x2
 #define MACHINE_TIMER_INTERRUPT           0x80000007
-#define TIMER_INTERRUPT_INTERVAL 0x00000600 // fot 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
+#define TIMER_INTERRUPT_INTERVAL 0x00000800 // for 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
 
 unsigned int COUNT_MACHINE_TIMER_INTRPT[1] = {0};
 
@@ -16,7 +16,7 @@ void mtime_routine_handler() {
 void interrupt_handler() {
 
     unsigned int mcause = read_mcause(); // read the CSR register for mcause to determine the cause of the interrupt
-    unsigned int csr_mepc, csr_mtval, csr_mstatus, mie_bit, mpie_bit, csr_mie, csr_mip;
+    unsigned int csr_mepc, csr_mtval;
 
     // For RISC-V, this value is 0x2 for illegal instruction
     if ((mcause & 0xFFF) == ILLEGAL_INSTRUCTION_EXCEPTION) { 
@@ -33,22 +33,10 @@ void interrupt_handler() {
 
     // For RISC-V, this value is 0x80000007 for machine timer interrupt
     if (mcause == MACHINE_TIMER_INTERRUPT) {
+        
         //Run the mtime interrupt handler routine
         mtime_routine_handler();
         
-        csr_mie = read_mie();
-        csr_mie = csr_mie | 0x00000888;
-        write_mie(csr_mie); // enable msie, mtie, meie bits in mie
-
-        csr_mstatus  = read_mstatus();
-        mpie_bit     = (csr_mstatus >> 7) & 0x1;   
-        csr_mstatus  = csr_mstatus | (mpie_bit << 3);  // set mie bit to be equal to mpie
-        csr_mstatus  = csr_mstatus & 0xFFFFFF7F;        // set mpie bit to 0
-        write_mstatus(csr_mstatus);                     // write mstatus back
-
-        csr_mip = 0;
-        write_mip(csr_mip); // clear msip, mtip, meip bits in mip
-        // update mtimecmp
         unsigned int csr_custom_mtime    = read_custom_mtime();
         unsigned int csr_custom_mtimecmp = read_custom_mtimecmp();
         

--- a/app/defines/interrupt_handler.h
+++ b/app/defines/interrupt_handler.h
@@ -5,8 +5,13 @@
 // RISCV mcause exceptions defines for detection: 
 #define ILLEGAL_INSTRUCTION_EXCEPTION     0x2
 #define MACHINE_TIMER_INTERRUPT           0x80000007
+#define TIMER_INTERRUPT_INTERVAL 0x00000600 // fot 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
 
-#define TIMER_INTERRUPT_INTERVAL 0x00003FFF // fot 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
+unsigned int COUNT_MACHINE_TIMER_INTRPT[1] = {0};
+
+void mtime_routine_handler() {
+        COUNT_MACHINE_TIMER_INTRPT[0]++;
+}
 
 void interrupt_handler() {
 
@@ -28,19 +33,8 @@ void interrupt_handler() {
 
     // For RISC-V, this value is 0x80000007 for machine timer interrupt
     if (mcause == MACHINE_TIMER_INTERRUPT) {
-        csr_mstatus  = read_mstatus();     
-        mie_bit  = (csr_mstatus >> 3) & 0x1;                // read mie bit from mstatus. mie = mstatus[3]
-        csr_mstatus = csr_mstatus & 0xFFFFFFF7;             // disable interrupts by setting mie bit to 0 in mstatus. 
-        csr_mstatus = csr_mstatus | (mie_bit << 7);        // save mie bit into mpie bit mstatus. mpie = mstatus[7]
-        write_mstatus(csr_mstatus);  
-
-        // disable msie, mtie, meie bits in mie
-        csr_mie = read_mie();                   
-        csr_mie = csr_mie & 0xFFFFF777; 
-        write_mie(csr_mie); 
-
-
-        rvc_printf("TIMER_INTERRUPT\n");
+        //Run the mtime interrupt handler routine
+        mtime_routine_handler();
         
         csr_mie = read_mie();
         csr_mie = csr_mie | 0x00000888;

--- a/app/defines/interrupt_handler.h
+++ b/app/defines/interrupt_handler.h
@@ -8,13 +8,7 @@
 #define TIMER_INTERRUPT_INTERVAL 0x00000600 // fot 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
 
 unsigned int COUNT_MACHINE_TIMER_INTRPT[1] = {0};
-#define TIMER_INTERRUPT_INTERVAL 0x00000600 // fot 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
 
-unsigned int COUNT_MACHINE_TIMER_INTRPT[1] = {0};
-
-void mtime_routine_handler() {
-        COUNT_MACHINE_TIMER_INTRPT[0]++;
-}
 void mtime_routine_handler() {
         COUNT_MACHINE_TIMER_INTRPT[0]++;
 }
@@ -65,4 +59,3 @@ void interrupt_handler() {
        }
 
 }
-

--- a/source/core_rrv/core_rrv.sv
+++ b/source/core_rrv/core_rrv.sv
@@ -56,6 +56,7 @@ logic [31:0]  DMemWrDataQ103H;
 logic [31:0]  CsrReadDataQ102H;      // data red from CSR
 logic [31:0]  CsrWriteDataQ102H;     // data writen to csr
 
+
 // Control bits
 logic                   BranchCondMetQ102H;
 logic                   ReadyQ100H;
@@ -73,7 +74,7 @@ t_ctrl_mem1             CtrlMem1;
 t_ctrl_wb               CtrlWb;
 t_csr_inst_rrv          CtrlCsr;
 t_csr_pc_update         CsrPcUpdateQ102H;
-t_csr_timer_interrupt   CsrTimerInterruptQ102H;
+logic                   TimerInterruptEnable;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 //   _____  __     __   _____   _        ______          ____    __    ___     ___    _    _ 
@@ -130,7 +131,7 @@ core_rrv_ctrl core_rrv_ctrl (
   // input feedback from data path
   .BranchCondMetQ102H   (BranchCondMetQ102H), //input
   .DMemReady            (DMemReady), //input
-  .CsrTimerInterruptQ102H  (CsrTimerInterruptQ102H), // input from csr unit
+  .TimerInterruptEnable (TimerInterruptEnable),
   // ready signals for "back-pressure" - use as the enable for the pipe stage sample
   .ReadyQ100H           (ReadyQ100H), //  output 
   .ReadyQ101H           (ReadyQ101H), //  output 
@@ -217,15 +218,14 @@ core_rrv_exe core_rrv_exe (
 core_rrv_csr core_rrv_csr (
  .Clk                       (Clock                  ),  
  .Rst                       (Rst                    ),  
- .PcQ102H                   (PcQ102H                ),
- .CsrTimerInterruptQ102H    (CsrTimerInterruptQ102H), 
+ .PcQ102H                   (PcQ102H                ), 
  // Inputs from the core
  .CsrInstQ102H              (CtrlCsr                ),
  .CsrWriteDataQ102H         (CsrWriteDataQ102H      ),
  .ValidInstQ105H            (ValidInstQ105H         ), 
  .CsrInterruptUpdateQ102H   (CsrInterruptUpdateQ102H), // FIXME: support hardware update for CSR (example: mstatus, mcause, ...)
  .CsrPcUpdateQ102H          (CsrPcUpdateQ102H       ), //output
- .interrupt_counter_expired (                       ),
+ .TimerInterruptEnable      (TimerInterruptEnable   ),
  // Outputs to the core
  .CsrReadDataQ102H          (CsrReadDataQ102H       )
 );

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -12,8 +12,7 @@ import core_rrv_pkg::*;
     input     ValidInstQ105H,
     // Outputs to the core
     output var t_csr_pc_update        CsrPcUpdateQ102H,
-    output var t_csr_timer_interrupt  CsrTimerInterruptQ102H,
-    output logic                      interrupt_counter_expired,
+    output logic                      TimerInterruptEnable,
     output logic [31:0]               CsrReadDataQ102H // 32-bit data read from the CSR
 );
 
@@ -42,11 +41,70 @@ logic csr_mcycle_overflow;
 logic csr_minstret_overflow;
 logic [63:0] csr_minstret_high_low;
 logic [63:0] csr_mcycle_high_low;
-logic [63:0] csr_instret_high_low;
-logic [63:0] csr_cycle_high_low;
+logic CsrMstatusMieBit, CsrMieMieBit;
 
+//==========================================================================
+// RO/V - read only from SW  , and may be updated from HW. Example: csr_cycle (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
+// RW/V - read/write from SW , and may be updated from HW. Example: csr_mcause (HW updates when exception occurs, then SW can read it and clear it)
+// RO   - read only from SW/HW , there is no write access. Example: csr_mvendorid
+// RW   - read/write from SW. Example: csr_scratch
 always_comb begin
-    next_csr = csr;
+    //==========================================================================
+    // default values - no change
+    //==========================================================================
+    next_csr             = csr;
+    CsrMstatusMieBit     = 0; 
+    CsrMieMieBit         = 0;
+    TimerInterruptEnable = 0;
+    //==========================================================================
+    // RW/V -> HW updates (may be overwritten by SW writes)
+    //==========================================================================
+    {csr_mcycle_overflow , next_csr.csr_mcycle}  = csr.csr_mcycle  + 1'b1;
+    next_csr.csr_mcycleh  = csr.csr_mcycleh + csr_mcycle_overflow;
+    csr_mcycle_high_low   = {csr.csr_mcycleh, csr.csr_mcycle}; //TODO - csr_mcycle_high_low is not part of the spec
+    if(ValidInstQ105H) begin
+        {csr_minstret_overflow , next_csr.csr_minstret}  = csr.csr_minstret + 1'b1;
+        next_csr.csr_minstreth = csr.csr_minstreth + csr_minstret_overflow;
+        csr_minstret_high_low  = {csr.csr_minstreth, csr.csr_minstret}; //TODO - csr_minstret_high_low is not part of the spec
+    end
+    if((csr.csr_custom_mtime >= csr.csr_custom_mtimecmp) && (csr.csr_custom_mtime!=0 && csr.csr_custom_mtimecmp!=0)) begin
+        next_csr.csr_mip     = 32'h80;
+        CsrMstatusMieBit     = csr.csr_mstatus[3]; 
+        CsrMieMieBit         = csr.csr_mie[7];
+        TimerInterruptEnable = CsrMstatusMieBit & CsrMieMieBit;
+    end
+    
+    //==========================================================================   
+    if(CsrInterruptUpdateQ102H.illegal_instruction) begin
+        next_csr.csr_mcause = 32'h00000002;
+        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
+    end
+    if(CsrInterruptUpdateQ102H.misaligned_access) begin
+        next_csr.csr_mcause = 32'h00000004;
+        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;//FIXME
+    end
+    if(CsrInterruptUpdateQ102H.illegal_csr_access) begin
+        next_csr.csr_mcause = 32'h0000000B;
+        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
+    end
+    if(CsrInterruptUpdateQ102H.breakpoint) begin
+        next_csr.csr_mcause = 32'h00000003;
+        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
+    end
+    if(CsrInterruptUpdateQ102H.timer_interrupt_taken) begin
+        next_csr.csr_mcause   = 32'h80000007;
+        next_csr.csr_mepc     = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mie      = 32'h00000808;  // disable mie 
+        next_csr.csr_mstatus  = 32'h00000080;  // mstatus[7] will be equall to mstatus[3]. If interrupt taken than mstatus[3] = 1
+    end
+
+    //==========================================================================
+    // SW writes
+    //==========================================================================
     if(csr_wren) begin
         unique casez ({csr_op,csr_addr}) // address holds the offset
             // ---- RW CSR ----
@@ -134,7 +192,7 @@ always_comb begin
             {2'b01, CSR_MEPC}    : next_csr.csr_mepc = csr_data;
             {2'b10, CSR_MEPC}    : next_csr.csr_mepc = csr.csr_mepc | csr_data;
             {2'b11, CSR_MEPC}    : next_csr.csr_mepc = csr.csr_mepc & ~csr_data;
-            // CSR_MCAUSE
+            // CSR_MCAUSE 
             {2'b01, CSR_MCAUSE}    : next_csr.csr_mcause = csr_data;
             {2'b10, CSR_MCAUSE}    : next_csr.csr_mcause = csr.csr_mcause | csr_data;
             {2'b11, CSR_MCAUSE}    : next_csr.csr_mcause = csr.csr_mcause & ~csr_data;
@@ -158,17 +216,11 @@ always_comb begin
             {2'b01, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr_data;
             {2'b10, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr.csr_custom_mtimecmp | csr_data;
             {2'b11, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr.csr_custom_mtimecmp & ~csr_data;
-
             // ---- Other ----
             default   : /* Do nothing */;
         endcase
-    end
-    //==========================================================================
-    // TODO - see what is the RISCV termology for the following:
-    // RO/V - read only from SW  , and may be updated from HW. Example: csr_cycle (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
-    // RW/V - read/write from SW , and may be updated from HW. Example: csr_mcause (HW updates when exception occurs, then SW can read it and clear it)
-    // RO   - read only from SW/HW , there is no write access. Example: csr_mvendorid
-    // RW   - read/write from SW. Example: csr_scratch
+    end // if(csr_wren)
+
     //==========================================================================
     // handle HW exceptions:
     //==========================================================================
@@ -176,71 +228,26 @@ always_comb begin
     // 2. misaligned access
     // 3. illegal CSR access
     // 4. breakpoint
-    //FIXME - please review the values of the exceptions - read the spec
-    if(CsrInterruptUpdateQ102H.illegal_instruction) begin
-        next_csr.csr_mcause = 32'h00000002;
-        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
-        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
-    end
-    if(CsrInterruptUpdateQ102H.misaligned_access) begin
-        next_csr.csr_mcause = 32'h00000004;
-        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
-        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
-    end
-    if(CsrInterruptUpdateQ102H.illegal_csr_access) begin
-        next_csr.csr_mcause = 32'h0000000B;
-        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
-        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
-    end
-    if(CsrInterruptUpdateQ102H.breakpoint) begin
-        next_csr.csr_mcause = 32'h00000003;
-        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
-        next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
-    end
-    if(CsrInterruptUpdateQ102H.timer_interrupt) begin
-        next_csr.csr_mcause = 32'h80000007;
-        next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
-    end
-
-    // handle HW interrupts:
-    // 1. timer interrupt
-    // 2. external interrupt
-    // TODO - possible fix that. commented by roman
-    //if(interrupt_counter_expired)     begin
-    //    next_csr.csr_mepc   = PcQ102H;
-    //end
-    //if(CsrInterruptUpdateQ102H.external_interrupt)  next_csr.csr_mcause = 32'h0000000B;
-
+    // ==========================================================================
     //==========================================================================
     // ---- RO/V CSR - writes from RTL ----
+    // RO/V - read only from SW  , and may be updated from HW. Example: csr_custom_mtime (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
     //==========================================================================
-        {csr_mcycle_overflow , next_csr.csr_mcycle}  = csr.csr_mcycle  + 1'b1;
-        next_csr.csr_mcycleh  = csr.csr_mcycleh + csr_mcycle_overflow;
-        csr_mcycle_high_low   = {csr.csr_mcycleh, csr.csr_mcycle}; //TODO - csr_mcycle_high_low is not part of the spec
-
-        if(ValidInstQ105H) begin
-            {csr_minstret_overflow , next_csr.csr_minstret}  = csr.csr_minstret + 1'b1;
-            next_csr.csr_minstreth = csr.csr_minstreth + csr_minstret_overflow;
-            csr_minstret_high_low  = {csr.csr_minstreth, csr.csr_minstret}; //TODO - csr_minstret_high_low is not part of the spec
-        end
-
-        next_csr.csr_custom_mtime = csr.csr_custom_mtime + 1'b1;
-        if((csr.csr_custom_mtime == csr.csr_custom_mtimecmp) && (csr.csr_custom_mtime!=0 && csr.csr_custom_mtimecmp!=0))
-            next_csr.csr_mip = 32'h80;
-
-        // URO CSR's
-        next_csr.csr_cycle    = next_csr.csr_mcycle;
-        next_csr.csr_cycleh   = next_csr.csr_mcycleh;
-        csr_cycle_high_low    = csr_mcycle_high_low;  
-        next_csr.csr_instret  = next_csr.csr_minstret;
-        next_csr.csr_instreth = next_csr.csr_minstreth;
-        csr_instret_high_low  = csr_minstret_high_low;      
+    next_csr.csr_custom_mtime = csr.csr_custom_mtime + 1'b1;
+    // the cycle & instret are accessable to read only -> only the mcycle & minstret are updated by the SW/HW
+    next_csr.csr_cycle    = next_csr.csr_mcycle;
+    next_csr.csr_cycleh   = next_csr.csr_mcycleh;
+    next_csr.csr_instret  = next_csr.csr_minstret;
+    next_csr.csr_instreth = next_csr.csr_minstreth;
     //==========================================================================
     // Reset values for CSR
     //==========================================================================
     if(Rst) begin
         next_csr = '0;
-        //May override the reset values
+        // ==================================================
+        // May override the reset values - add the values here
+        // ==================================================
+        // next_csr.csr_misa = 32'h40001104;
     end // if(Rst)
     //==========================================================================
     // READ ONLY - constant values
@@ -310,22 +317,14 @@ end
 logic  BeginInterrupt;
 assign BeginInterrupt = (CsrInterruptUpdateQ102H.illegal_instruction || CsrInterruptUpdateQ102H.misaligned_access 
                        || CsrInterruptUpdateQ102H.illegal_csr_access || CsrInterruptUpdateQ102H.breakpoint 
-                       || CsrInterruptUpdateQ102H.external_interrupt || CsrInterruptUpdateQ102H.timer_interrupt);
+                       || CsrInterruptUpdateQ102H.external_interrupt || CsrInterruptUpdateQ102H.timer_interrupt_taken);
 
 assign CsrPcUpdateQ102H.InterruptJumpEnQ102H       = BeginInterrupt;
 assign CsrPcUpdateQ102H.InterruptJumpAddressQ102H  = csr.csr_mtvec;
 assign CsrPcUpdateQ102H.InteruptReturnEnQ102H      = CsrInterruptUpdateQ102H.Mret;
 assign CsrPcUpdateQ102H.InteruptReturnAddressQ102H = csr.csr_mepc;
 
-assign CsrTimerInterruptQ102H.csr_mstatus          = csr.csr_mstatus;
-assign CsrTimerInterruptQ102H.csr_mie              = csr.csr_mie;
-assign CsrTimerInterruptQ102H.csr_custom_mtime     = csr.csr_custom_mtime;
-assign CsrTimerInterruptQ102H.csr_custom_mtimecmp  = csr.csr_custom_mtimecmp;
 
-always_comb begin
-    //create an interrupt if the cycle counter is equal to the compare value
-    interrupt_counter_expired = '0;// csr.csr_cycle_low == csr.csr_scratch;
-end
 
   
 endmodule

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -96,11 +96,18 @@ always_comb begin
         next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
     end
     if(CsrInterruptUpdateQ102H.timer_interrupt_taken) begin
+        TimerInterruptEnable  = 0;
         next_csr.csr_mcause   = 32'h80000007;
         next_csr.csr_mepc     = CsrInterruptUpdateQ102H.Pc;
         next_csr.csr_mie      = 32'h00000808;  // disable mie 
         next_csr.csr_mstatus  = 32'h00000080;  // mstatus[7] will be equall to mstatus[3]. If interrupt taken than mstatus[3] = 1
     end
+    if(CsrInterruptUpdateQ102H.Mret) begin
+            next_csr.csr_mie     = 32'h00000888;  // enable mie
+            next_csr.csr_mstatus = 32'h00000008;
+            next_csr.csr_mip     = 32'h0; 
+    end
+
 
     //==========================================================================
     // SW writes

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -48,11 +48,6 @@ logic CsrMstatusMieBit, CsrMieMieBit;
 // RW/V - read/write from SW , and may be updated from HW. Example: csr_mcause (HW updates when exception occurs, then SW can read it and clear it)
 // RO   - read only from SW/HW , there is no write access. Example: csr_mvendorid
 // RW   - read/write from SW. Example: csr_scratch
-//==========================================================================
-// RO/V - read only from SW  , and may be updated from HW. Example: csr_cycle (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
-// RW/V - read/write from SW , and may be updated from HW. Example: csr_mcause (HW updates when exception occurs, then SW can read it and clear it)
-// RO   - read only from SW/HW , there is no write access. Example: csr_mvendorid
-// RW   - read/write from SW. Example: csr_scratch
 always_comb begin
     //==========================================================================
     // default values - no change
@@ -198,7 +193,6 @@ always_comb begin
             {2'b10, CSR_MEPC}    : next_csr.csr_mepc = csr.csr_mepc | csr_data;
             {2'b11, CSR_MEPC}    : next_csr.csr_mepc = csr.csr_mepc & ~csr_data;
             // CSR_MCAUSE 
-            // CSR_MCAUSE 
             {2'b01, CSR_MCAUSE}    : next_csr.csr_mcause = csr_data;
             {2'b10, CSR_MCAUSE}    : next_csr.csr_mcause = csr.csr_mcause | csr_data;
             {2'b11, CSR_MCAUSE}    : next_csr.csr_mcause = csr.csr_mcause & ~csr_data;
@@ -227,8 +221,6 @@ always_comb begin
         endcase
     end // if(csr_wren)
 
-    end // if(csr_wren)
-
     //==========================================================================
     // handle HW exceptions:
     //==========================================================================
@@ -237,18 +229,10 @@ always_comb begin
     // 3. illegal CSR access
     // 4. breakpoint
     // ==========================================================================
-    // ==========================================================================
     //==========================================================================
     // ---- RO/V CSR - writes from RTL ----
     // RO/V - read only from SW  , and may be updated from HW. Example: csr_custom_mtime (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
-    // RO/V - read only from SW  , and may be updated from HW. Example: csr_custom_mtime (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
     //==========================================================================
-    next_csr.csr_custom_mtime = csr.csr_custom_mtime + 1'b1;
-    // the cycle & instret are accessable to read only -> only the mcycle & minstret are updated by the SW/HW
-    next_csr.csr_cycle    = next_csr.csr_mcycle;
-    next_csr.csr_cycleh   = next_csr.csr_mcycleh;
-    next_csr.csr_instret  = next_csr.csr_minstret;
-    next_csr.csr_instreth = next_csr.csr_minstreth;
     next_csr.csr_custom_mtime = csr.csr_custom_mtime + 1'b1;
     // the cycle & instret are accessable to read only -> only the mcycle & minstret are updated by the SW/HW
     next_csr.csr_cycle    = next_csr.csr_mcycle;
@@ -260,10 +244,6 @@ always_comb begin
     //==========================================================================
     if(Rst) begin
         next_csr = '0;
-        // ==================================================
-        // May override the reset values - add the values here
-        // ==================================================
-        // next_csr.csr_misa = 32'h40001104;
         // ==================================================
         // May override the reset values - add the values here
         // ==================================================

--- a/source/core_rrv/packages/core_rrv_csr_pkg.vh
+++ b/source/core_rrv/packages/core_rrv_csr_pkg.vh
@@ -79,20 +79,13 @@ typedef struct packed {
     logic misaligned_access;
     logic illegal_csr_access;
     logic breakpoint;
-    logic timer_interrupt;  
+    logic timer_interrupt_taken;  
     logic external_interrupt;
     logic Mret;
     logic [31:0] mtval_instruction;
     logic [31:0] csr_mip;
     logic [31:0] Pc; 
 } t_csr_interrupt_update;
-
-typedef struct packed {
-    logic [31:0] csr_mstatus;
-    logic [31:0] csr_mie;
-    logic [31:0] csr_custom_mtime;
-    logic [31:0] csr_custom_mtimecmp;
-} t_csr_timer_interrupt;
 
 typedef struct packed {
     logic        InterruptJumpEnQ102H;


### PR DESCRIPTION

I chose to implement our initial version and execute the instruction once the timer interrupt is triggered. This approach is adopted because, upon deciding to handle an exception by inserting NOPs, we ensure that interrupts are processed when there are no NOPs, thereby avoiding a loop. I tested this with several timers and employed the method you demonstrated for comparing valid instructions, which appears to be working.

All the updated of relevant csrs are handled in CSR module and not in the software.
