### PR TITLE
add lfsr Tests

### DIFF
--- a/app/defines/interrupt_handler.h
+++ b/app/defines/interrupt_handler.h
@@ -5,7 +5,7 @@
 // RISCV mcause exceptions defines for detection: 
 #define ILLEGAL_INSTRUCTION_EXCEPTION     0x2
 #define MACHINE_TIMER_INTERRUPT           0x80000007
-#define TIMER_INTERRUPT_INTERVAL 0x00000800 // for 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
+#define TIMER_INTERRUPT_INTERVAL 0x00000500 // for 2 timer interrupts set to 0x0000004F and comment line 8 in alive_illegal.c
 
 unsigned int COUNT_MACHINE_TIMER_INTRPT[1] = {0};
 

--- a/scripts/rand_pseudo_num_gen.py
+++ b/scripts/rand_pseudo_num_gen.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import os
+
+# Use the current working directory
+directory = os.getcwd()
+
+# Ensure the directory exists
+if not os.path.exists(directory):
+    os.makedirs(directory)
+
+# Function to perform the LFSR operation with right shift
+def lfsr_32_bit(seed):
+    # Polynomial: x^32 + x^22 + x^2 + x^1 + 1
+    # Tap positions for right shift: considering Python's 0-based indexing
+    taps = [31, 21, 1, 0]
+    lfsr = seed
+    period = 0
+
+    with open(os.path.join(directory, 'lfsr_output.txt'), 'w') as f:
+        while True:
+            # Calculate the feedback bit for right shift
+            feedback_bit = (lfsr & 1) ^ ((lfsr >> 21) & 1) ^ ((lfsr >> 1) & 1) ^ ((lfsr >> 31) & 1)
+            
+            # Shift right and insert the feedback bit on the left
+            lfsr = (lfsr >> 1) | (feedback_bit << 31)
+            lfsr &= 0xFFFFFFFF  # Ensure lfsr stays 32-bit
+
+            # Write the LFSR value in hexadecimal form
+            f.write(f'{lfsr:08X}\n')  # Format as 8-digit hexadecimal
+            
+            period += 1
+            if period >= 100:  # Limit the output for demonstration purposes
+                break
+
+# Initial seed (must be non-zero)
+seed = 0xACE1
+lfsr_32_bit(seed)
+
+print(f"LFSR output stored in {os.path.join(directory, 'lfsr_output.txt')}")

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -42,6 +42,7 @@ logic csr_minstret_overflow;
 logic [63:0] csr_minstret_high_low;
 logic [63:0] csr_mcycle_high_low;
 logic CsrMstatusMieBit, CsrMieMieBit;
+logic left_lfsr_bit;
 
 //==========================================================================
 // RO/V - read only from SW  , and may be updated from HW. Example: csr_cycle (HW updates it, SW can read it - NOTE: the mcycle is RW/V)
@@ -108,7 +109,10 @@ always_comb begin
             next_csr.csr_mip     = 32'h0; 
     end
 
-
+    //==========================================================
+    //32bit lfsr. Polynom: x^32 + x^22 + x^2 + x^1 + 1
+    left_lfsr_bit =  (csr.csr_custom_lfsr[31]) ^ (csr.csr_custom_lfsr[21]) ^ (csr.csr_custom_lfsr[1]) ^ (csr.csr_custom_lfsr[0]);
+    next_csr.csr_custom_lfsr = {left_lfsr_bit, csr.csr_custom_lfsr[31:1]};
     //==========================================================================
     // SW writes
     //==========================================================================
@@ -223,6 +227,10 @@ always_comb begin
             {2'b01, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr_data;
             {2'b10, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr.csr_custom_mtimecmp | csr_data;
             {2'b11, CSR_CUSTOM_MTIMECMP}    : next_csr.csr_custom_mtimecmp = csr.csr_custom_mtimecmp & ~csr_data;
+            // CSR_CUSTOM_LFSR
+            {2'b01, CSR_CUSTOM_LFSR}        : next_csr.csr_custom_lfsr = csr_data;
+            {2'b10, CSR_CUSTOM_LFSR}        : next_csr.csr_custom_lfsr = csr.csr_custom_lfsr  | csr_data;
+            {2'b11, CSR_CUSTOM_LFSR}        : next_csr.csr_custom_lfsr = csr.csr_custom_lfsr  & ~csr_data;
             // ---- Other ----
             default   : /* Do nothing */;
         endcase

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -263,6 +263,7 @@ always_comb begin
         // May override the reset values - add the values here
         // ==================================================
         // next_csr.csr_misa = 32'h40001104;
+        next_csr.csr_custom_lfsr = 32'hACE1; //seed initialization
     end // if(Rst)
     //==========================================================================
     // READ ONLY - constant values

--- a/source/core_rrv/core_rrv_ctrl.sv
+++ b/source/core_rrv/core_rrv_ctrl.sv
@@ -98,11 +98,9 @@ assign IllegalInstructionQ101H = (PreIllegalInstructionQ101H) && ! (flushQ102H |
 logic JumpOrBranch;
 assign JumpOrBranch = (OpcodeQ101H == BRANCH) || (OpcodeQ101H == JAL) || (OpcodeQ101H == JALR); 
 
-logic TimerInterruptTakenQ101H, TimerInterruptTakenQ102H, TimerInterruptTakenQ103H;
+logic TimerInterruptTakenQ101H, TimerInterruptTakenQ102H;
 assign TimerInterruptTakenQ101H = (TimerInterruptEnable) & (PreValidInstQ101H) & !(JumpOrBranch) & !(IllegalInstructionQ101H);
 `MAFIA_EN_RST_DFF(TimerInterruptTakenQ102H, TimerInterruptTakenQ101H, Clock, ReadyQ102H, Rst )
-`MAFIA_EN_RST_DFF(TimerInterruptTakenQ103H, TimerInterruptTakenQ102H, Clock, ReadyQ103H, Rst )
-
 
 logic LoadHazardValidRegSrc2Q101H;
 logic RegDstQ102MatchRegSrc1Q101H;

--- a/source/core_rrv/packages/core_rrv_csr_pkg.vh
+++ b/source/core_rrv/packages/core_rrv_csr_pkg.vh
@@ -71,7 +71,9 @@ typedef enum logic [11:0] {
  CSR_MTVAL2          = 12'h34B,
  //Custom csr's for mtime, mtimecmp
  CSR_CUSTOM_MTIME    = 12'hFC0,
- CSR_CUSTOM_MTIMECMP = 12'hBC0
+ CSR_CUSTOM_MTIMECMP = 12'hBC0,
+ //Custom csr used for LFSR 
+ CSR_CUSTOM_LFSR     = 12'hBC1
 } t_csr_addr ;
 
 typedef struct packed {
@@ -132,6 +134,7 @@ typedef struct packed {
     logic [31:0] csr_mtval2;
     logic [31:0] csr_custom_mtime;
     logic [31:0] csr_custom_mtimecmp;
+    logic [31:0] csr_custom_lfsr;
 } t_csr;
 
 typedef struct packed {

--- a/verif/core_rrv/regress/rv32i_level0
+++ b/verif/core_rrv/regress/rv32i_level0
@@ -3,5 +3,6 @@ basic.c             -gRF_NUM_MSB=31
 alive_csr.c         -gRF_NUM_MSB=31
 alive_vga.c         -gRF_NUM_MSB=31
 bubblesort.c        -gRF_NUM_MSB=31
+alive_lfsr.c        -gRF_NUM_MSB=31
 data_hazard_check.s -gRF_NUM_MSB=31
 store_load_check.s  -gRF_NUM_MSB=31

--- a/verif/core_rrv/regress/rv32i_level0_cfg_intrpt
+++ b/verif/core_rrv/regress/rv32i_level0_cfg_intrpt
@@ -1,2 +1,3 @@
-alive_illegal.c     -gRF_NUM_MSB=31
+alive_illegal.c          -gRF_NUM_MSB=31
 bubblesort_with_timer.c -gRF_NUM_MSB=31
+bubblesort_lfsr.c      -gRF_NUM_MSB=31

--- a/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
@@ -112,7 +112,7 @@ initial begin: test_seq
    
 end // test_seq
 
-parameter V_TIMEOUT = 100000;
+parameter V_TIMEOUT = 500000;
 parameter RF_NUM_MSB = 31; // NOTE!!!: auto inserted from script ovrd_params.py
 initial begin: detect_timeout
     //=======================================

--- a/verif/core_rrv/tb/core_rrv_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_tb.sv
@@ -139,7 +139,7 @@ initial begin: test_seq
    
 end // test_seq
 
-parameter V_TIMEOUT = 100000;
+parameter V_TIMEOUT = 500000;
 parameter RF_NUM_MSB = 31; // NOTE!!!: auto inserted from script ovrd_params.py
 initial begin: detect_timeout
     //=======================================

--- a/verif/core_rrv/tests/alive_lfsr.c
+++ b/verif/core_rrv/tests/alive_lfsr.c
@@ -1,0 +1,43 @@
+
+//------------------------------------------------------------
+// Title : alive_lfsr
+// Project : core_rrv
+//------------------------------------------------------------
+// Description :
+//generating LENGTH pseudo random numbers created using LFSR
+//------------------------------------------------------------
+#include "big_core_defines.h"
+#include "graphic_vga.h"
+#define LENGTH 10
+
+// Function to generate the next LFSR value
+unsigned int lfsr(unsigned int current_state) {
+    // Feedback polynomial: x^8 + x^6 + x^5 + x^4 + 1
+    // We use taps at positions 8, 6, 5, and 4.
+    unsigned int bit = ((current_state >> 7) ^ (current_state >> 5) ^ (current_state >> 4) ^ (current_state >> 3)) & 1;
+    return (current_state << 1) | bit; // Shift left and add feedback bit
+}
+
+// Function to generate a pseudo-random number in the range 0-99
+unsigned int lfsr_random_0_99(unsigned int seed) {
+    unsigned int random_value = 0;
+    for (int i = 0; i < 7; ++i) { // Generate 7 bits
+        seed = lfsr(seed); // Update LFSR state
+        random_value = (random_value << 1) | (seed & 1); // Append LSB of LFSR state to random_value
+    }
+    return random_value % 100; // Modulate by 100 to get a range of 0-99
+}
+
+int main() {
+    unsigned int seed = 0xACE1u; // Non-zero seed
+    unsigned int random_numbers[LENGTH];
+
+    // Fill the array with pseudo-random numbers within the range 0-99
+    for (int i = 0; i < LENGTH; ++i) {
+        random_numbers[i] = lfsr_random_0_99(seed + i); // Use varying seeds for each number
+        rvc_print_int(random_numbers[i]);
+        rvc_printf(" ");
+    }
+
+    return 0;
+}

--- a/verif/core_rrv/tests/bubblesort_lfsr.c
+++ b/verif/core_rrv/tests/bubblesort_lfsr.c
@@ -1,0 +1,89 @@
+
+//------------------------------------------------------------
+// Title : alive_lfsr
+// Project : core_rrv
+//------------------------------------------------------------
+// Description :
+//generating LENGTH pseudo random numbers created using LFSR
+//------------------------------------------------------------
+#include "interrupt_handler.h"
+
+#define LENGTH 15
+
+// Function to generate the next LFSR value
+unsigned int lfsr(unsigned int current_state) {
+    // Feedback polynomial: x^8 + x^6 + x^5 + x^4 + 1
+    // We use taps at positions 8, 6, 5, and 4.
+    unsigned int bit = ((current_state >> 7) ^ (current_state >> 5) ^ (current_state >> 4) ^ (current_state >> 3)) & 1;
+    return (current_state << 1) | bit; // Shift left and add feedback bit
+}
+
+// Function to generate a pseudo-random number in the range 0-99
+unsigned int lfsr_random_0_99(unsigned int seed) {
+    unsigned int random_value = 0;
+    for (int i = 0; i < 7; ++i) { // Generate 7 bits
+        seed = lfsr(seed); // Update LFSR state
+        random_value = (random_value << 1) | (seed & 1); // Append LSB of LFSR state to random_value
+    }
+    return random_value % 100; // Modulate by 100 to get a range of 0-99
+}
+
+void bubbleSort(int arr[], int n) {
+    int i, j;
+    for (i = 0; i < n-1; i++) {
+        for (j = 0; j < n-i-1; j++) {
+            if (arr[j] > arr[j+1]) {
+                int temp = arr[j];
+                arr[j] = arr[j+1];
+                arr[j+1] = temp;
+            }
+        }
+    }
+}
+
+void printSorted(int arr[], int n){
+    int i;
+    for (i = 0; i < n; i++) {
+        rvc_print_int(arr[i]);
+        rvc_printf(" ");
+    }
+}
+
+int check_sort(int arr[], int n){
+    int i;
+    for(i=0; i < n-1; i++){
+        if(arr[i] > arr[i+1])
+            return 0;
+        i++;
+    }
+
+    return 1; 
+}
+int main() {    
+    //enable the mie timer interrupts CSR:
+    unsigned int csr_mie = read_mie();
+    csr_mie = csr_mie | 0x00000888;
+    write_mie(csr_mie); // enable msie, mtie, meie bits in mie
+
+    unsigned int seed = 0xACE1u; // Non-zero seed
+    unsigned int random_numbers[LENGTH];
+
+    // Fill the array with pseudo-random numbers within the range 0-99
+    for (int i = 0; i < LENGTH; ++i) 
+        random_numbers[i] = lfsr_random_0_99(seed + i); // Use varying seeds for each number
+
+    int n = sizeof(random_numbers)/sizeof(random_numbers[0]);
+
+    bubbleSort(random_numbers, n);
+    //printSorted(random_numbers, n); // leave that line comment for shorter V_TIMEOUT
+
+    if(check_sort(random_numbers, n))
+        rvc_printf("SORT PASS\n");
+    else    
+        rvc_printf("SORT FAILD\n");
+
+    rvc_print_int(COUNT_MACHINE_TIMER_INTRPT[0]);
+
+
+    return 0;
+}

--- a/verif/core_rrv/tests/bubblesort_with_timer.c
+++ b/verif/core_rrv/tests/bubblesort_with_timer.c
@@ -15,7 +15,7 @@ void bubbleSort(int arr[], int n) {
 
 void printSorted(int arr[], int n){
     int i;
-    for (i = 0; i < n-1; i++) {
+    for (i = 0; i < n; i++) {
         rvc_print_int(arr[i]);
         rvc_printf(" ");
     }


### PR DESCRIPTION
- `alive_lfsr.c` - regular test with LFSR. Number range between 0-99
- `bubblesort_lfsr.c` -  LFSR test with interrupt timer. Number range between 0-99. For shorted TB time I just print if the array is sorted or not.
### LFSR HW implementation
I started to work on HW implementation of the LFSR. 
- I added a custom read/write csr. 
- I initialize it with a seed inside csr unit in the reset block.
- I am using Polynomial that was suggested in the literature to get the maximum period as possible (2^32 - 1)
-  I created a very basic script to generate numbers with the same seed and Polynomial as in HW to test the LFSR and it gives the same results.
I will add a task to compare between HW results and SW results.
To run this script : 
```
./scripts/rand_pseudo_num_gen.py 
````
It will generate a file with random values inside `fpga_mafia` main folder. **OF COURSE** I will change its location and possible add some flags to the script after we discuss our further steps.

By the book, at each cycle the LFSR generates 1 random bit  (its the lsb bit) so to create an integer we will have to wait 32 cycles, I think its not practical and instead of working by the book, we can treat to the whole LFSR register as 32 bit changed every 1 cycle. See the values in gui:
![image](https://github.com/FPGA-MAFIA/fpga_mafia/assets/57875954/77084c52-2703-4a00-a087-0c7e842dc99d)
 