### PR TITLE
fix bug #PR467.

### DIFF
--- a/app/crt0/crt0_boot_trap.s
+++ b/app/crt0/crt0_boot_trap.s
@@ -46,7 +46,7 @@ csr_init:
   csrw mtvec, t0    # Write the value in t0 to the mtvec CSR
 
   # Enable software and external interrupts. Set msie, meie  fields Disable the mtie timer interrupt 
-  li t0, 0x808
+  li t0, 0x888
   csrw	mie, t0     
   
   # Enable interrupts. Set MIE and MPIE bit to 1 and 0 respectively in mstatus register.

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -76,6 +76,13 @@ always_comb begin
     end
     
     //==========================================================================   
+    if(CsrInterruptUpdateQ102H.timer_interrupt_taken) begin
+        TimerInterruptEnable  = 0;
+        next_csr.csr_mcause   = 32'h80000007;
+        next_csr.csr_mepc     = CsrInterruptUpdateQ102H.Pc;
+        next_csr.csr_mie      = 32'h00000808;  // disable mie 
+        next_csr.csr_mstatus  = 32'h00000080;  // mstatus[7] will be equall to mstatus[3]. If interrupt taken than mstatus[3] = 1
+    end
     if(CsrInterruptUpdateQ102H.illegal_instruction) begin
         next_csr.csr_mcause = 32'h00000002;
         next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
@@ -96,14 +103,7 @@ always_comb begin
         next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
         next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
     end
-    if(CsrInterruptUpdateQ102H.timer_interrupt_taken) begin
-        TimerInterruptEnable  = 0;
-        next_csr.csr_mcause   = 32'h80000007;
-        next_csr.csr_mepc     = CsrInterruptUpdateQ102H.Pc;
-        next_csr.csr_mie      = 32'h00000808;  // disable mie 
-        next_csr.csr_mstatus  = 32'h00000080;  // mstatus[7] will be equall to mstatus[3]. If interrupt taken than mstatus[3] = 1
-    end
-    if(CsrInterruptUpdateQ102H.Mret) begin
+    if(CsrInterruptUpdateQ102H.Mret && csr.csr_mip) begin
             next_csr.csr_mie     = 32'h00000888;  // enable mie
             next_csr.csr_mstatus = 32'h00000008;
             next_csr.csr_mip     = 32'h0; 

--- a/source/core_rrv/core_rrv_csr.sv
+++ b/source/core_rrv/core_rrv_csr.sv
@@ -103,7 +103,7 @@ always_comb begin
         next_csr.csr_mepc   = CsrInterruptUpdateQ102H.Pc;
         next_csr.csr_mtval  = CsrInterruptUpdateQ102H.mtval_instruction;
     end
-    if(CsrInterruptUpdateQ102H.Mret && csr.csr_mip) begin
+    if(CsrInterruptUpdateQ102H.Mret && csr.csr_mip[7]) begin
             next_csr.csr_mie     = 32'h00000888;  // enable mie
             next_csr.csr_mstatus = 32'h00000008;
             next_csr.csr_mip     = 32'h0; 

--- a/source/core_rrv/core_rrv_ctrl.sv
+++ b/source/core_rrv/core_rrv_ctrl.sv
@@ -111,11 +111,11 @@ assign  LoadHazardValidRegSrc2Q101H = PreOpcodeQ101H == R_OP || PreOpcodeQ101H =
 // Load Hazard 1 detection - between pipe stage 102 and 101
 assign  RegDstQ102MatchRegSrc1Q101H = (PreRegSrc1Q101H == CtrlQ102H.RegDst) && ValidInstQ102H && (CtrlQ102H.Opcode == LOAD);
 assign  RegDstQ102MatchRegSrc2Q101H = (PreRegSrc2Q101H == CtrlQ102H.RegDst) && ValidInstQ102H && (CtrlQ102H.Opcode == LOAD) && (LoadHazardValidRegSrc2Q101H);
-assign  LoadHzrd1DetectQ101H        =   RegDstQ102MatchRegSrc1Q101H || RegDstQ102MatchRegSrc2Q101H;
+assign  LoadHzrd1DetectQ101H        = (RegDstQ102MatchRegSrc1Q101H || RegDstQ102MatchRegSrc2Q101H);
 // Load Hazard 2 detection - between pipe stage 103 and 101
 assign  RegDstQ103MatchRegSrc1Q101H = (PreRegSrc1Q101H == CtrlQ103H.RegDst) && ValidInstQ103H && (CtrlQ103H.Opcode == LOAD);
 assign  RegDstQ103MatchRegSrc2Q101H = (PreRegSrc2Q101H == CtrlQ103H.RegDst) && ValidInstQ103H && (CtrlQ103H.Opcode == LOAD) && (LoadHazardValidRegSrc2Q101H);
-assign  LoadHzrd2DetectQ101H        =  RegDstQ103MatchRegSrc1Q101H ||  RegDstQ103MatchRegSrc2Q101H;          
+assign  LoadHzrd2DetectQ101H        = (RegDstQ103MatchRegSrc1Q101H ||  RegDstQ103MatchRegSrc2Q101H);          
 //incase of a jump/branch we select the ALU out in pipe stage 102, which means we need to flush the pipe for 2 cycles:
 logic IndirectBranchQ102H;
 assign IndirectBranchQ102H = (CtrlQ102H.SelNextPcAluOutB && BranchCondMetQ102H) || (CtrlQ102H.SelNextPcAluOutJ);
@@ -253,7 +253,9 @@ assign ReadyQ105H = (!CoreFreeze); // FIXME - this is back pressure from mem_wra
 assign ReadyQ104H = (!CoreFreeze);
 assign ReadyQ103H = (!CoreFreeze);
 assign ReadyQ102H = (!CoreFreeze);//
-assign ReadyQ101H = ((!CoreFreeze) && !(LoadHzrd1DetectQ101H || LoadHzrd2DetectQ101H)) || flushQ102H; //
+assign ReadyQ101H = ((!CoreFreeze) && !(LoadHzrd1DetectQ101H || LoadHzrd2DetectQ101H)) || flushQ102H || flushQ103H; 
+
+//assign ReadyQ101H = ((!CoreFreeze) && !(LoadHzrd1DetectQ101H || LoadHzrd2DetectQ101H)) || flushQ102H; //
 //assign ReadyQ101H = flushQ102H ? 1'b1 : (!CoreFreeze) && !(LoadHzrd1DetectQ101H || LoadHzrd2DetectQ101H);
 assign ReadyQ100H = (!CoreFreeze) && ReadyQ101H;//
 // Sample the Ctrl bits through the pipe

--- a/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
+++ b/verif/core_rrv/tb/core_rrv_no_ref_tb.sv
@@ -112,7 +112,7 @@ initial begin: test_seq
    
 end // test_seq
 
-parameter V_TIMEOUT = 500000;
+parameter V_TIMEOUT = 1000000;
 parameter RF_NUM_MSB = 31; // NOTE!!!: auto inserted from script ovrd_params.py
 initial begin: detect_timeout
     //=======================================


### PR DESCRIPTION
I add an option to avoid stalling when calling timer interrupt, I add a condition in csr module to enable the interrupts when mret is happening only when we have timer interrupt (in the future we will change to more interrupts)