### PR TITLE
refactor tb of ps2_kbd

### DIFF
--- a/verif/ps2_kbd/tb/ps2_kbd_verif_list.f
+++ b/verif/ps2_kbd/tb/ps2_kbd_verif_list.f
@@ -1,1 +1,2 @@
 ../../../verif/ps2_kbd/tb/sp_converter_tb.sv
+../../../verif/ps2_kbd/tb/sp_converter_tb2.sv

--- a/verif/ps2_kbd/tb/sp_converter_tb.sv
+++ b/verif/ps2_kbd/tb/sp_converter_tb.sv
@@ -14,10 +14,9 @@
 
 
 module sp_converter_tb();
-
-    
+ 
     logic Rst, KbdClk, KbdSerialData, ParallelDataReady;
-    logic [7:0] ParallelData;
+    logic [7:0]  ParallelData;
     logic [10:0] packetW;
     logic [10:0] packetRelease;
     
@@ -39,7 +38,7 @@ module sp_converter_tb();
     // ========================
     initial begin: reset_gen
          Rst = 1'b1;
-    #100 Rst = 1'b0;
+    #50  Rst = 1'b0;
     end: reset_gen
     
     sp_converter sp_converter(
@@ -52,10 +51,10 @@ module sp_converter_tb();
     
     initial begin : main
         
-        // transfering 0x31d 'w'
+        // transfering 0x23A 'w'
         $display("The tranfered packet is %1h", packetW);
 
-        #10 KbdSerialData <= packetW[0];
+        #50 KbdSerialData <= packetW[0];
         
         #10 KbdSerialData <= packetW[1];
         
@@ -89,7 +88,7 @@ module sp_converter_tb();
 
         #10 KbdSerialData <= packetRelease[0];
         
-        #10 KbdSerialData <=packetRelease[1];
+        #10 KbdSerialData <= packetRelease[1];
 
         #10 KbdSerialData <= packetRelease[2];
 
@@ -120,7 +119,18 @@ module sp_converter_tb();
         $display("Test has finished");
 
         $finish();
-    end     
+    end    
+
+parameter V_TIMEOUT = 100000;
+initial begin: detect_timeout
+    //=======================================
+    // timeout
+    //=======================================
+    #V_TIMEOUT 
+    $error("test ended with timeout");
+    $display("ERROR: No data integrity running - try to increase the timeout value");
+    $finish;
+end 
 endmodule
 
 


### PR DESCRIPTION
I added 2 TB, they both seems to be identical in delay timing but I got different results in simulations and I cant understand why.
For example:
`sp_converter_tb.sv'  when Rst goes to zero `PackBitCounter` Goes to one.  its were the yellow line
```
./build.py -dut ps2_kbd -test alive -hw -sim -top sp_converter_tb -clean -gui
````
![image](https://github.com/FPGA-MAFIA/fpga_mafia/assets/57875954/27a3f991-981a-44d9-a02f-b82dd783e3cd)

`sp_converter_tb2' when Rst goes to zero `PackBitCounter` Goes to one one cycle latter. This TB works. its were yellow line. Inspite in simulation the parallel output is correct, wait statement do not working probably as I expected
```
./build.py -dut ps2_kbd -test alive -hw -sim -top sp_converter_tb2 -clean -gui
```
![image](https://github.com/FPGA-MAFIA/fpga_mafia/assets/57875954/c0cfd190-af82-4eed-9907-f282598bc6d6)

