### PR TITLE
add tracker for VGA, CR, DATA memory read/writes

### DIFF
--- a/app/defines/string.h
+++ b/app/defines/string.h
@@ -1,5 +1,5 @@
-#ifndef STRINGS_H
-#define STRINGS_H
+#ifndef STRING_H
+#define STRING_H
 
 int atoi(const char *str) {
     int result = 0;


### PR DESCRIPTION
- I have added 3 trackers. Each one tracks independently reads/writes related to VGA region, CR region and DATA region.
- I have tested the data memory tracker using both `core_rrv` and `mini_core` while running the same test on both of them and got the same results. I assumed that `mini_core` data memory tracker is correct. 
