### PR TITLE
debug and fix state machine - works!

### DIFF
--- a/source/sdram_fsm/sdram_fsm.sv
+++ b/source/sdram_fsm/sdram_fsm.sv
@@ -42,16 +42,16 @@ import sdram_fsm_pkg::*;
 
     // Initialization of WriteFromMeme with seven segment data (DE10 lite has a low active outputs)
     always_comb begin
-        WriteFromMem[0] = 7'b1000000;
-        WriteFromMem[1] = 7'b1111001;
-        WriteFromMem[2] = 7'b0100100;
-        WriteFromMem[3] = 7'b0110000;
-        WriteFromMem[4] = 7'b0011001;
-        WriteFromMem[5] = 7'b0010010;
-        WriteFromMem[6] = 7'b0000010;
-        WriteFromMem[7] = 7'b1111000;
-        WriteFromMem[8] = 7'b0000000;
-        WriteFromMem[9] = 7'b0010000;
+        WriteFromMem[0] = 7'b1000000;  // 0x40
+        WriteFromMem[1] = 7'b1111001;  // 0x79
+        WriteFromMem[2] = 7'b0100100;  // 0x24
+        WriteFromMem[3] = 7'b0110000;  // 0x30
+        WriteFromMem[4] = 7'b0011001;  // 0x19
+        WriteFromMem[5] = 7'b0010010;  // 0x12
+        WriteFromMem[6] = 7'b0000010;  // 0x02
+        WriteFromMem[7] = 7'b1111000;  // 0x78
+        WriteFromMem[8] = 7'b0000000;  // 0x00
+        WriteFromMem[9] = 7'b0010000;  // 0x10
     end
     
 
@@ -63,7 +63,9 @@ import sdram_fsm_pkg::*;
             Counter <= Next_counter;
     end
 
-    assign Next_counter    = (Counter == 4'ha) ? 4'h0 : Counter + 1;
+    logic IncCounterEn;
+    assign IncCounterEn = (state == WRITE & state != READ) || (state != WRITE & state == READ);
+    assign Next_counter    = (Counter == 4'ha || !IncCounterEn) ? 4'h0 : Counter + 1;
     assign OnProgress      = !(Counter == 4'ha);
 
     // state register
@@ -87,7 +89,7 @@ import sdram_fsm_pkg::*;
         case(state)
             IDLE : begin
                 if (StartWr) 
-                    next_state = READ;
+                    next_state = WRITE;
                 else
                     next_state = IDLE;
             end

--- a/source/sdram_fsm/sdram_fsm_top.sv
+++ b/source/sdram_fsm/sdram_fsm_top.sv
@@ -39,7 +39,7 @@ import sdram_fsm_pkg::*;
 sdram_fsm sdram_fsm 
 (
     .Clock(Clock),  
-    .nRst(!nRst),
+    .nRst(nRst),
     .StartWr(StartWr), // start writing to memory
     // write to sdram interface
     .WrRequest(WrRequest),    // write request - start writing to FIFO  

--- a/verif/sdram_fsm/tb/sdram_fsm_tb.sv
+++ b/verif/sdram_fsm/tb/sdram_fsm_tb.sv
@@ -10,6 +10,8 @@
 //-----------------------------------------------------------------------------
 // Description :
 //-----------------------------------------------------------------------------
+
+// to run type in the terminal ./build.py -dut sdram_fsm -hw -sim
 `ifndef sdram_fsm_TB_SV
 `define sdram_fsm_TB_SV
 
@@ -46,8 +48,9 @@ string test_name;
 initial begin: test_seq
     if ($value$plusargs ("STRING=%s", test_name))
         $display("STRING value %s", test_name);
-    #40
+    #35
         $display("Test Start");
+        StartWr = 1'b1;
 
     wait(sdram_fsm_top.Done) begin
         $display("Test is finished");
@@ -57,7 +60,7 @@ initial begin: test_seq
 
 end // test_seq
 
-parameter V_TIMEOUT = 100000;
+parameter V_TIMEOUT = 1000;
 initial begin : time_out_detection
     #V_TIMEOUT
     $error("Time out reached");


### PR DESCRIPTION
The state machine writes all 10 digits and reads them as expected! 
Just for better understanding: I tried to find the signals that indicates if memory is ready for write or for read and did not find them anywhere. The clock of the SDRAM is 100Mhz which is twicer than FPGA clock and read latency is 2 cycles and than if I conclude right than FPGA can receive data on its each rising edge of its 50Mhz clock.  The FIFO for read and write uses  2 stage synchronizer because of different clock domains. The unit that generates the test as seen in their example also operates at 100Mhz.

Next step is to integrate it in Quartus example