### PR TITLE
Considering adding M extension to the big core

### DIFF
--- a/verif/big_core/tests/mult.c
+++ b/verif/big_core/tests/mult.c
@@ -1,0 +1,33 @@
+//------------------------------------------------------------------------------------------------------
+// Description:
+// This test aims to compare IPC (Instructions Per Cycle) by performing 
+// multiplication of 32-bit integers using an RV32I core without the 'M' extension
+// and without using dedicated hardware. When dealing with large numbers, approximately 500 cycles
+// are added per 1 multiplication. With the use of basic multiplier hardware such as the 
+// "shift and add" method, up to 32 cycles are added per multiplication. This results in an 
+// approximate speedup of x15 times per multiplication.
+// To perform that analysis COMMENT the included libraries and print functions and Watch the `trk_cpi_ipc_trk.log' file
+//-------------------------------------------------------------------------------------------------------
+
+#include "big_core_defines.h"
+#include "graphic_vga.h"
+
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+int main() {
+    uint32_t x = 2147483647; 
+    uint32_t y = 2147483647;
+
+    uint64_t z = (uint64_t)x * y;  // Full 64-bit multiplication
+    uint32_t low = (uint32_t)(z & 0xFFFFFFFF);  // Extract lower 32 bits
+    uint32_t high = (uint32_t)(z >> 32);  // Extract upper 32 bits
+
+    // Use 'low' and 'high' as needed
+    // comment those functions and the libraries to perform more accurate analysis using `trk_cpi_ipc_trk.log' file
+    rvc_print_int(low);  
+    rvc_printf("\n");
+    rvc_print_int(high);
+
+    return 0;
+}


### PR DESCRIPTION
I want to integrate the M extension into the big_core:

- We anticipate frequent use of multiplication in future applications.
- The big_core is typically designed as an RV32IM core within the broader mafia architecture, as illustrated in the general architecture image.
- This will enable our students to better understand the necessity of accelerators for AI applications by comparing multiplication results across the RV32I, RV32IM, and accelerator-enhanced environments.
- **The added hardware is relatively smaller compared to the future cores and tiles we want to add**.

I conducted a test to compare the Instructions Per Cycle (IPC) of a single multiplication using the RV32I architecture. For longer numbers, we observe an additional 500 clock cycles approximately. 

This test was conducted for two main reasons:

1. Observe the performance of multiplying two large integers that can produce more than a 32-bit result in `RV32I` architecture and test the necessity of 'M' extension.
2. To ensure the compiler uses the `mul` and `mulh` instructions correctly, to do so I modified the code and changed the `-march` flag value to `rv32im` in config file. Although I was unable to run the simulations, I could examine the assembly file.

Conclusions: Each multiplication with relatively long numbers adds about 500 clocks as seen in the first figure. Using the simplest multiplier like the "shift and add" method, requires up to 32 or 128 cycles. The 128-cycle scenario occurs when the compiler splits the multiplication into four instructions of multiplication as shown in the second figure(I am not using any compiler optimization here). 
**I plan to study this further to get precise comparison**, but it is evident that even with a basic multiplier, we achieve significant speed improvement

![image](https://github.com/FPGA-MAFIA/fpga_mafia/assets/57875954/67f9000e-25d9-4cbe-8f4f-ecbcceaaa23c)
![image](https://github.com/FPGA-MAFIA/fpga_mafia/assets/57875954/d70a9ec7-53f4-48fb-b701-b737eb1d2f6a)

* Additional information in discussion #640 .
* After previous discussion I probably will choose Booth Multiplier because of its efficiency and less complexity relative to Wallace Tree Multiplier that is more efficient but more complex 
* Its possible to consider adding new config file with `-march rv32im'