### PR TITLE
Mini core accel - integrate systolic array accelerator

### DIFF
--- a/app/defines/mini_core_accel_defines.h
+++ b/app/defines/mini_core_accel_defines.h
@@ -119,12 +119,38 @@
 //==================================
 //  define CR's for systolic array
 //==================================
-#define SYSTOLIC_ARRAY_WEIGHTS    = ((volatile int *) (CR_MEM_BASE + 0xF200));
-#define SYSTOLIC_ARRAY_ACTIVE     = ((volatile int *) (CR_MEM_BASE + 0xF201));
-#define SYSTOLIC_ARRAY_START      = ((volatile int *) (CR_MEM_BASE + 0xF202));
-#define SYSTOLIC_ARRAY_VALID      = ((volatile int *) (CR_MEM_BASE + 0xF203));
+#define SYSTOLIC_ARRAY_WEIGHTS31_0    ((volatile int *) (CR_MEM_BASE + 0xF200))
+#define SYSTOLIC_ARRAY_WEIGHTS63_32   ((volatile int *) (CR_MEM_BASE + 0xF201))
+#define SYSTOLIC_ARRAY_WEIGHTS95_64   ((volatile int *) (CR_MEM_BASE + 0xF202))
+#define SYSTOLIC_ARRAY_WEIGHTS127_96  ((volatile int *) (CR_MEM_BASE + 0xF203))
+#define SYSTOLIC_ARRAY_ACTIVE31_0     ((volatile int *) (CR_MEM_BASE + 0xF204))
+#define SYSTOLIC_ARRAY_ACTIVE63_32    ((volatile int *) (CR_MEM_BASE + 0xF205))
+#define SYSTOLIC_ARRAY_ACTIVE95_64    ((volatile int *) (CR_MEM_BASE + 0xF206))
+#define SYSTOLIC_ARRAY_ACTIVE127_96   ((volatile int *) (CR_MEM_BASE + 0xF207))
+#define SYSTOLIC_ARRAY_START          ((volatile int *) (CR_MEM_BASE + 0xF208))
+#define SYSTOLIC_ARRAY_VALID          ((volatile int *) (CR_MEM_BASE + 0xF209))
 
-// used for debug purposes
+#define PE00_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20A))
+#define PE01_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20B))
+#define PE02_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20C))
+#define PE03_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20D))
+#define PE10_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20E))
+#define PE11_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF20F))
+#define PE12_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF210))
+#define PE13_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF211))
+#define PE20_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF212))
+#define PE21_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF213))
+#define PE22_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF214))
+#define PE23_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF215))
+#define PE30_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF216))
+#define PE31_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF217))
+#define PE32_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF218))
+#define PE33_RESULT                   ((volatile int *) (CR_MEM_BASE + 0xF219))
+
+
+//=====================================
+//   define CR's for dwbug purposes
+//=====================================
 #define CR_DEBUG_0 ((volatile int *) (CR_MEM_BASE + 0xFF00))
 #define CR_DEBUG_1 ((volatile int *) (CR_MEM_BASE + 0xFF01))
 #define CR_DEBUG_2 ((volatile int *) (CR_MEM_BASE + 0xFF02))

--- a/source/mini_core_accel/accelerators/mini_core_accel_farm.sv
+++ b/source/mini_core_accel/accelerators/mini_core_accel_farm.sv
@@ -38,6 +38,15 @@ generate
     end
 endgenerate
 
+                            
+systolic_array_top systolic_array_top
+(
+    .clk(clock),
+    .rst(rst),
+    .cr_systolic_array_input(accel_farm_input.cr_systolic_array),
+    .cr_systolic_array_output(accel_farm_output.cr_systolic_array)
+);
+
 
 endmodule
 

--- a/source/mini_core_accel/accelerators/systolic_array/pe_unit.sv
+++ b/source/mini_core_accel/accelerators/systolic_array/pe_unit.sv
@@ -9,7 +9,7 @@ import mini_core_accel_pkg::*;
     input logic                 rst,
     input var t_pe_unit_input   pe_inputs,
     output var t_pe_unit_output pe_outputs,
-    output int16                result
+    output int16                result   // TODO consider make the output int8
 );
 
 

--- a/source/mini_core_accel/accelerators/systolic_array/systolic_array_top.sv
+++ b/source/mini_core_accel/accelerators/systolic_array/systolic_array_top.sv
@@ -1,0 +1,61 @@
+`include "macros.vh"
+// that module is intantiate the systolic array (systolic_array_ctrl.sv)
+// the main goal of that model is to hide all the assignments from mini_core_accel_farm
+// so we do the assignments here
+
+module systolic_array_top
+import mini_core_accel_pkg::*;
+(
+    input logic                     clk,
+    input logic                     rst,
+    input var t_cr_systolic_array   cr_systolic_array_input,
+    output var t_cr_systolic_array  cr_systolic_array_output
+
+);
+
+
+logic [127:0] systolic_array_weights;
+logic [127:0] systolic_array_avtivations;
+assign        systolic_array_weights    =  {cr_systolic_array_input.cr_systolic_array_weights127_96, 
+                                            cr_systolic_array_input.cr_systolic_array_weights95_64,
+                                            cr_systolic_array_input.cr_systolic_array_weights63_32,
+                                            cr_systolic_array_input.cr_systolic_array_weights31_0};
+
+assign        systolic_array_avtivations = {cr_systolic_array_input.cr_systolic_array_active127_96, 
+                                            cr_systolic_array_input.cr_systolic_array_active95_64,
+                                            cr_systolic_array_input.cr_systolic_array_active63_32,
+                                            cr_systolic_array_input.cr_systolic_array_active31_0};  
+
+
+t_pe_results pe_results_to_cr;
+
+assign cr_systolic_array_output.cr_pe00_result = pe_results_to_cr.pe00_result;
+assign cr_systolic_array_output.cr_pe01_result = pe_results_to_cr.pe01_result;
+assign cr_systolic_array_output.cr_pe02_result = pe_results_to_cr.pe02_result;
+assign cr_systolic_array_output.cr_pe03_result = pe_results_to_cr.pe03_result;
+assign cr_systolic_array_output.cr_pe10_result = pe_results_to_cr.pe10_result;
+assign cr_systolic_array_output.cr_pe11_result = pe_results_to_cr.pe11_result;
+assign cr_systolic_array_output.cr_pe12_result = pe_results_to_cr.pe12_result;
+assign cr_systolic_array_output.cr_pe13_result = pe_results_to_cr.pe13_result;
+assign cr_systolic_array_output.cr_pe20_result = pe_results_to_cr.pe20_result;
+assign cr_systolic_array_output.cr_pe21_result = pe_results_to_cr.pe21_result;
+assign cr_systolic_array_output.cr_pe22_result = pe_results_to_cr.pe22_result;
+assign cr_systolic_array_output.cr_pe23_result = pe_results_to_cr.pe23_result;
+assign cr_systolic_array_output.cr_pe30_result = pe_results_to_cr.pe30_result;
+assign cr_systolic_array_output.cr_pe31_result = pe_results_to_cr.pe31_result;
+assign cr_systolic_array_output.cr_pe32_result = pe_results_to_cr.pe32_result;
+assign cr_systolic_array_output.cr_pe33_result = pe_results_to_cr.pe33_result;
+
+systolic_array_ctrl systolic_array_ctrl
+(
+    .clk(clk),
+    .rst(rst),
+    .all_weights(systolic_array_weights),                                 // hard wired to cr's
+    .all_activations(systolic_array_avtivations),                         // hard wired to cr's
+    .start(cr_systolic_array_input.cr_systolic_array_start),   // hard wired to cr
+    .valid(cr_systolic_array_output.cr_systolic_array_valid),  // hard wired to cr data is valid 
+    .pe_results(pe_results_to_cr)
+
+);
+
+endmodule

--- a/source/mini_core_accel/mini_core_accel_pkg.sv
+++ b/source/mini_core_accel/mini_core_accel_pkg.sv
@@ -48,16 +48,16 @@ typedef struct packed {
 parameter DIMENTION = 4;  // 4x4 grid. Do not change the grid size without updating structs
 
 typedef struct packed{
-    int8  weight;
-    int8  activation;
-    logic start;
-    logic done;   
+    int8  weight;     // input weight
+    int8  activation; // input activation
+    logic start;      // start calculation
+    logic done;       // stop calculation
 } t_pe_unit_input;
 
 typedef struct packed {
-    int8  activation;
-    int8  weight;
-    logic done;
+    int8  activation;  // activation passed to neighboured PE's
+    int8  weight;      // weight passed to neighboured PE's
+    logic done;        // done signal passing neighboured PE's
 } t_pe_unit_output;
 
 typedef struct packed { // naming of each element is treated as a matrix 4x4 elements
@@ -80,10 +80,33 @@ typedef struct packed { // naming of each element is treated as a matrix 4x4 ele
 } t_pe_results;
 
 typedef struct packed{
-    logic [127:0] cr_systolic_array_weights;
-    logic [127:0] cr_systolic_array_active;
+    logic [31:0]  cr_systolic_array_weights31_0;
+    logic [31:0]  cr_systolic_array_weights63_32;
+    logic [31:0]  cr_systolic_array_weights95_64;
+    logic [31:0]  cr_systolic_array_weights127_96;
+    logic [31:0]  cr_systolic_array_active31_0;
+    logic [31:0]  cr_systolic_array_active63_32;
+    logic [31:0]  cr_systolic_array_active95_64;
+    logic [31:0]  cr_systolic_array_active127_96;
     logic         cr_systolic_array_start;
     logic         cr_systolic_array_valid;
+    // results
+    int16         cr_pe00_result;
+    int16         cr_pe01_result;
+    int16         cr_pe02_result;
+    int16         cr_pe03_result;
+    int16         cr_pe10_result;
+    int16         cr_pe11_result;
+    int16         cr_pe12_result;
+    int16         cr_pe13_result;
+    int16         cr_pe20_result;
+    int16         cr_pe21_result;
+    int16         cr_pe22_result;
+    int16         cr_pe23_result;
+    int16         cr_pe30_result;
+    int16         cr_pe31_result;
+    int16         cr_pe32_result;
+    int16         cr_pe33_result;
 } t_cr_systolic_array;
 
 typedef enum {
@@ -136,12 +159,14 @@ typedef struct packed {
 typedef struct packed { 
     t_mul_int8_input   [INT8_MULTIPLIER_NUM-1:0] core2mul_int8;      // {multiplicand, multiplier}
     t_neuron_mac_input [NEURON_MAC_NUM-1:0]      int8_mul2neuron_mac;  // {mul_result[7:0][15:0], bias}
+    t_cr_systolic_array                          cr_systolic_array;  
 }t_accel_farm_input;
 
 // response from multiplier 
 typedef struct packed {
     t_mul_int8_output   [INT8_MULTIPLIER_NUM-1:0] mul2core_int8;
     t_neuron_mac_output [NEURON_MAC_NUM-1:0]      neuron_mac_result;
+    t_cr_systolic_array                           cr_systolic_array;
 }t_accel_farm_output;
 
 
@@ -235,12 +260,38 @@ parameter NEURON_MAC_RESULT1       = CR_MEM_OFFSET + 'hf103;
 //=====================================
 //   define CR's for systolic array
 //=====================================
-parameter SYSTOLIC_ARRAY_WEIGHTS    = CR_MEM_OFFSET + 'hf200;
-parameter SYSTOLIC_ARRAY_ACTIVE     = CR_MEM_OFFSET + 'hf201;
-parameter SYSTOLIC_ARRAY_START      = CR_MEM_OFFSET + 'hf202;
-parameter SYSTOLIC_ARRAY_VALID      = CR_MEM_OFFSET + 'hf203;
+parameter SYSTOLIC_ARRAY_WEIGHTS31_0    = CR_MEM_OFFSET + 'hf200;
+parameter SYSTOLIC_ARRAY_WEIGHTS63_32   = CR_MEM_OFFSET + 'hf201;
+parameter SYSTOLIC_ARRAY_WEIGHTS95_64   = CR_MEM_OFFSET + 'hf202;
+parameter SYSTOLIC_ARRAY_WEIGHTS127_96  = CR_MEM_OFFSET + 'hf203;
+parameter SYSTOLIC_ARRAY_ACTIVE31_0     = CR_MEM_OFFSET + 'hf204;
+parameter SYSTOLIC_ARRAY_ACTIVE63_32    = CR_MEM_OFFSET + 'hf205;
+parameter SYSTOLIC_ARRAY_ACTIVE95_64    = CR_MEM_OFFSET + 'hf206;
+parameter SYSTOLIC_ARRAY_ACTIVE127_96   = CR_MEM_OFFSET + 'hf207;
+parameter SYSTOLIC_ARRAY_START          = CR_MEM_OFFSET + 'hf208;
+parameter SYSTOLIC_ARRAY_VALID          = CR_MEM_OFFSET + 'hf209;
 
-// used for debug purposes
+parameter PE00_RESULT                   = CR_MEM_OFFSET + 'hf20a;
+parameter PE01_RESULT                   = CR_MEM_OFFSET + 'hf20b;
+parameter PE02_RESULT                   = CR_MEM_OFFSET + 'hf20c;
+parameter PE03_RESULT                   = CR_MEM_OFFSET + 'hf20d;
+parameter PE10_RESULT                   = CR_MEM_OFFSET + 'hf20e;
+parameter PE11_RESULT                   = CR_MEM_OFFSET + 'hf20f;
+parameter PE12_RESULT                   = CR_MEM_OFFSET + 'hf210;
+parameter PE13_RESULT                   = CR_MEM_OFFSET + 'hf211;
+parameter PE20_RESULT                   = CR_MEM_OFFSET + 'hf212;
+parameter PE21_RESULT                   = CR_MEM_OFFSET + 'hf213;
+parameter PE22_RESULT                   = CR_MEM_OFFSET + 'hf214;
+parameter PE23_RESULT                   = CR_MEM_OFFSET + 'hf215;
+parameter PE30_RESULT                   = CR_MEM_OFFSET + 'hf216;
+parameter PE31_RESULT                   = CR_MEM_OFFSET + 'hf217;
+parameter PE32_RESULT                   = CR_MEM_OFFSET + 'hf218;
+parameter PE33_RESULT                   = CR_MEM_OFFSET + 'hf219;
+
+
+//=====================================
+//   define CR's for dwbug purposes
+//=====================================
 parameter CR_DEBUG_0                = CR_MEM_OFFSET + 'hff00;
 parameter CR_DEBUG_1                = CR_MEM_OFFSET + 'hff01;
 parameter CR_DEBUG_2                = CR_MEM_OFFSET + 'hff02;

--- a/source/mini_core_accel/mini_core_accel_rtl_list.f
+++ b/source/mini_core_accel/mini_core_accel_rtl_list.f
@@ -47,4 +47,4 @@
 ../../../source/mini_core_accel/accelerators/systolic_array/pe_unit.sv
 ../../../source/mini_core_accel/accelerators/systolic_array/systolic_array_net.sv
 ../../../source/mini_core_accel/accelerators/systolic_array/systolic_array_ctrl.sv
-
+../../../source/mini_core_accel/accelerators/systolic_array/systolic_array_top.sv

--- a/verif/mini_core_accel/tests/systolic_array_test.c
+++ b/verif/mini_core_accel/tests/systolic_array_test.c
@@ -1,0 +1,40 @@
+//===========================================================
+// testing 4x4 systolic array grid
+//===========================================================
+
+//./build.py -dut mini_core_accel -test systolic_array_test -app -hw -sim -clean
+
+#include "mini_core_accel_defines.h"
+#include "mafia_accel.h"
+
+
+int main() {
+
+    // initialize activations (inputs) and weights
+    int8_t activations[4][4] = {{1,2,3,4}, {5,6,7,8}, {9,10,11,12}, {13,14,15,16}};
+    int8_t weights[4][4]     = {{2,3,4,5}, {6,7,8,9}, {10,11,12,13}, {14,15,16,17}};
+    
+    // set systolic array CR's with data
+    set_systolic_array(activations, weights); // re-arrange the systolic array value.
+                                              // Writing the function here will save some clock cycles wasted for jump and return   
+
+    // starting calculation
+    int start = 1;
+    WRITE_REG(SYSTOLIC_ARRAY_START, start);
+
+    int polling = 0;
+
+    while(!polling){
+        READ_REG(polling, SYSTOLIC_ARRAY_VALID);  
+    }
+
+    // Call systolic_array_result function to get the results
+    int16_t (*results)[4] = systolic_array_result();  // No need to declare the matrix here
+
+    // reset systolic array for next calculation
+    start = 0;
+    WRITE_REG(SYSTOLIC_ARRAY_START, start);
+
+
+    return 0;
+}


### PR DESCRIPTION
- Design on 4x4 systolic array grid
- Integration of the grid to work with `mini_core_accel`
- Perform dedicated tests to check functionality

I run 4x4 matrix multiplication using `for loops` to see the performance and I got `x13` in speed up. I can increase the speed up even more. Its super easy to increase the systilolic array size and get much more speed up. 

![image](https://github.com/user-attachments/assets/0eda78d5-d359-407d-b65b-64d6ef06259e)

![image](https://github.com/user-attachments/assets/3be53e07-dcc1-46d9-bd72-8fcd5385c0aa)
