### PR TITLE
Abd lnker crt sbss fix

### DIFF
--- a/app/crt0/crt0_boot_trap.s
+++ b/app/crt0/crt0_boot_trap.s
@@ -57,15 +57,24 @@ csr_init:
   li t0, 0x00000500
   csrw 0xBC0, t0    
 
-stack_init:
+  /* stack initialization */
   la   x2, _stack_start
 
-jump_to_main:
+  /* Zero initialize .sbss section */
+zero_sbss:
+  la t0, __sbss_start   /* t0 = start of .sbss */
+  la t1, __sbss_end     /* t1 = end of .sbss */
+zero_sbss_loop:
+  bge t0, t1, jump_main /* If t0 >= t1, proceed to main */
+  sw x0, 0(t0)          /* Store zero in .sbss */
+  addi t0, t0, 4        /* Increment t0 */
+  j zero_sbss_loop      /* Repeat for next word */
+
+jump_main:
   jal x1, main  //jump to main
   nop
-  ebreak        //end                 
+  ebreak        //end                    
   .section .text
-
 
   
 ###############################################

--- a/app/crt0/crt0_boot_trap.s
+++ b/app/crt0/crt0_boot_trap.s
@@ -8,6 +8,41 @@ _start:
   nop                       
   nop                       
   nop                       
+
+reset_handler:
+  /* Initialize registers */
+  mv  x1, x0
+  mv  x2, x1
+  mv  x3, x1
+  mv  x4, x1
+  mv  x5, x1
+  mv  x6, x1
+  mv  x7, x1
+  mv  x8, x1
+  mv  x9, x1
+  mv x10, x1
+  mv x11, x1
+  mv x12, x1
+  mv x13, x1
+  mv x14, x1
+  mv x15, x1
+  mv x16, x1
+  mv x17, x1
+  mv x18, x1
+  mv x19, x1
+  mv x20, x1
+  mv x21, x1
+  mv x22, x1
+  mv x23, x1
+  mv x24, x1
+  mv x25, x1
+  mv x26, x1
+  mv x27, x1
+  mv x28, x1
+  mv x29, x1
+  mv x30, x1
+  mv x31, x1
+
   j init_handler            # Jump to the initialization handler after NOPs
 
 ###############################################
@@ -94,40 +129,6 @@ restore_and_return:
 # --------------------------------------------------
 
 init_handler:
-
-reset_handler:
-  /* Initialize registers */
-  mv  x1, x0
-  mv  x2, x1
-  mv  x3, x1
-  mv  x4, x1
-  mv  x5, x1
-  mv  x6, x1
-  mv  x7, x1
-  mv  x8, x1
-  mv  x9, x1
-  mv x10, x1
-  mv x11, x1
-  mv x12, x1
-  mv x13, x1
-  mv x14, x1
-  mv x15, x1
-  mv x16, x1
-  mv x17, x1
-  mv x18, x1
-  mv x19, x1
-  mv x20, x1
-  mv x21, x1
-  mv x22, x1
-  mv x23, x1
-  mv x24, x1
-  mv x25, x1
-  mv x26, x1
-  mv x27, x1
-  mv x28, x1
-  mv x29, x1
-  mv x30, x1
-  mv x31, x1
 
 csr_init:
   li t0, 0x100      # Load the immediate value 0x100 of trap handler address

--- a/app/crt0/crt0_default.s
+++ b/app/crt0/crt0_default.s
@@ -1,4 +1,4 @@
-_start:
+ _start:
   .global _start
   .org 0x00
   nop                       
@@ -6,7 +6,9 @@ _start:
   nop                       
   nop                       
   nop                       
+
 reset_handler:
+  /* Initialize registers to zero (optional) */
   mv  x1, x0
   mv  x2, x1
   mv  x3, x1
@@ -38,7 +40,8 @@ reset_handler:
   mv x29, x1
   mv x30, x1
   mv x31, x1
-  /* stack initialization */
+
+  /* Stack initialization */
   la   x2, _stack_start
 
   /* Zero initialize .sbss section */
@@ -46,19 +49,27 @@ zero_sbss:
   la t0, __sbss_start   /* t0 = start of .sbss */
   la t1, __sbss_end     /* t1 = end of .sbss */
 zero_sbss_loop:
-  bge t0, t1, jump_main /* If t0 >= t1, proceed to main */
+  bge t0, t1, zero_bss  /* If t0 >= t1, proceed to zeroing .bss */
   sw x0, 0(t0)          /* Store zero in .sbss */
   addi t0, t0, 4        /* Increment t0 */
   j zero_sbss_loop      /* Repeat for next word */
 
+  /* Zero initialize .bss section */
+zero_bss:
+  la t0, __bss_start    /* t0 = start of .bss */
+  la t1, __bss_end      /* t1 = end of .bss */
+zero_bss_loop:
+  bge t0, t1, jump_main /* If t0 >= t1, proceed to main */
+  sw x0, 0(t0)          /* Store zero in .bss */
+  addi t0, t0, 4        /* Increment t0 */
+  j zero_bss_loop       /* Repeat for next word */
+
 jump_main:
-  jal x1, main  //jump to main
+  jal x1, main          /* Jump to main */
   nop
-  ebreak        //end                    
+  ebreak                /* End */
   .section .text
-
-
-  
+ 
 ##################################################
 # Interrupt handler for the counter in location 
 ##################################################

--- a/app/crt0/crt0_default.s
+++ b/app/crt0/crt0_default.s
@@ -41,6 +41,17 @@ reset_handler:
   /* stack initialization */
   la   x2, _stack_start
 
+  /* Zero initialize .sbss section */
+zero_sbss:
+  la t0, __sbss_start   /* t0 = start of .sbss */
+  la t1, __sbss_end     /* t1 = end of .sbss */
+zero_sbss_loop:
+  bge t0, t1, jump_main /* If t0 >= t1, proceed to main */
+  sw x0, 0(t0)          /* Store zero in .sbss */
+  addi t0, t0, 4        /* Increment t0 */
+  j zero_sbss_loop      /* Repeat for next word */
+
+jump_main:
   jal x1, main  //jump to main
   nop
   ebreak        //end                    

--- a/app/defines/graphic_vga.h
+++ b/app/defines/graphic_vga.h
@@ -265,7 +265,7 @@ unsigned int ASCII_BTM[128] = {
 
 
 /* ANIME tables */
-unsigned int ANIME_TOP[6]    = {WALK_MAN_TOP_0,   WALK_MAN_TOP_1,   WALK_MAN_TOP_2,   WALK_MAN_TOP_3,   WALK_MAN_TOP_4,   CLEAR_TOP};
+unsigned int ANIME_TOP[6] = {WALK_MAN_TOP_0,   WALK_MAN_TOP_1,   WALK_MAN_TOP_2,   WALK_MAN_TOP_3,   WALK_MAN_TOP_4,   CLEAR_TOP};
 unsigned int ANIME_BTM[6] = {WALK_MAN_BTM_0,WALK_MAN_BTM_1,WALK_MAN_BTM_2,WALK_MAN_BTM_3,WALK_MAN_BTM_4,CLEAR_BTM};
 
 /* Control registers addresses */

--- a/app/link.common.ld
+++ b/app/link.common.ld
@@ -1,18 +1,20 @@
+
 MEMORY {  
     i_mem          : ORIGIN = I_MEM_OFFSET , LENGTH = I_MEM_LENGTH  
     global_data    : ORIGIN = D_MEM_OFFSET , LENGTH = D_MEM_LENGTH  
 }  
 
-
 _stack_start   = ORIGIN(global_data) + LENGTH(global_data);
 
 SECTIONS {  
+    /* Code section */
     .text : {  
         . = ALIGN(4);  
         *(.start);  
         *(.text);  
     } > i_mem 
 
+    /* Read-Only Data section */
     .rodata : {
         . = ALIGN(4);
         *(.rodata);
@@ -20,15 +22,32 @@ SECTIONS {
         LONG(0); /* Pad the last word to 32 bits if necessary*/
     } > global_data
 
+    /* Initialized Data section */
     .data : {  
         . = ALIGN(4);  
+        _sdata = .;                /* Start of .data in RAM */
         *(.data);  
         LONG(0); /* Pad the last word to 32 bits if necessary*/
         *(.sdata);  
         LONG(0); /* Pad the last word to 32 bits if necessary*/
+        _edata = .;                /* End of .data in RAM */
+    } > global_data AT > i_mem   /* Load from i_mem, run from global_data */
+
+    /* Uninitialized Small Data section (.sbss) */
+    .sbss (NOLOAD) : {  
+        . = ALIGN(4);
+        __sbss_start = .;          /* Start of .sbss */
         *(.sbss);  
         LONG(0); /* Pad the last word to 32 bits if necessary*/
+        __sbss_end = .;            /* End of .sbss */
+    } > global_data  
+
+    /* Uninitialized Data section (.bss) */
+    .bss (NOLOAD) : {  
+        . = ALIGN(4);
+        __bss_start = .;           /* Start of .bss */
         *(.bss);  
         LONG(0); /* Pad the last word to 32 bits if necessary*/
+        __bss_end = .;             /* End of .bss */
     } > global_data  
 }

--- a/app/link.common.ld
+++ b/app/link.common.ld
@@ -1,44 +1,40 @@
-
 MEMORY {  
     i_mem          : ORIGIN = I_MEM_OFFSET , LENGTH = I_MEM_LENGTH  
     global_data    : ORIGIN = D_MEM_OFFSET , LENGTH = D_MEM_LENGTH  
-}  
+}
 
 _stack_start   = ORIGIN(global_data) + LENGTH(global_data);
 
 SECTIONS {  
-    /* Code section */
+    /* Code section loaded into instruction memory */
     .text : {  
         . = ALIGN(4);  
         *(.start);  
         *(.text);  
     } > i_mem 
 
-    /* Read-Only Data section */
+    /* Read-Only Data loaded into global_data (RAM) */
     .rodata : {
         . = ALIGN(4);
         *(.rodata);
         . = ALIGN(4);
-        LONG(0); /* Pad the last word to 32 bits if necessary*/
+        LONG(0); /* Pad the last word to 32 bits if necessary */
     } > global_data
 
-    /* Initialized Data section */
+    /* Initialized Data section directly in global_data */
     .data : {  
         . = ALIGN(4);  
-        _sdata = .;                /* Start of .data in RAM */
         *(.data);  
-        LONG(0); /* Pad the last word to 32 bits if necessary*/
+        LONG(0); /* Pad the last word to 32 bits if necessary */
         *(.sdata);  
-        LONG(0); /* Pad the last word to 32 bits if necessary*/
-        _edata = .;                /* End of .data in RAM */
-    } > global_data AT > i_mem   /* Load from i_mem, run from global_data */
+        LONG(0); /* Pad the last word to 32 bits if necessary */
+    } > global_data  
 
     /* Uninitialized Small Data section (.sbss) */
     .sbss (NOLOAD) : {  
         . = ALIGN(4);
         __sbss_start = .;          /* Start of .sbss */
         *(.sbss);  
-        LONG(0); /* Pad the last word to 32 bits if necessary*/
         __sbss_end = .;            /* End of .sbss */
     } > global_data  
 
@@ -47,7 +43,6 @@ SECTIONS {
         . = ALIGN(4);
         __bss_start = .;           /* Start of .bss */
         *(.bss);  
-        LONG(0); /* Pad the last word to 32 bits if necessary*/
         __bss_end = .;             /* End of .bss */
     } > global_data  
 }

--- a/verif/big_core_cachel1/tb/trk/big_core_cachel1_ref_trk.vh
+++ b/verif/big_core_cachel1/tb/trk/big_core_cachel1_ref_trk.vh
@@ -16,3 +16,24 @@ always @(posedge Clk) begin : memory_ref_access_print
     end
 end
 
+// new tracker for all writes to the register file 
+// track PC, register destination, and the data written to the register
+integer trk_ref_reg_write_data;
+
+initial begin: trk_ref_reg_write_data_gen
+#1
+    trk_ref_reg_write_data = $fopen({"../../../target/big_core_cachel1/tests/",test_name,"/trk_ref_reg_write_data.log"},"w");
+    $fwrite(trk_ref_reg_write_data,"---------------------------------------------------------\n");
+    $fwrite(trk_ref_reg_write_data," PC | reg_dst | data \n");
+    $fwrite(trk_ref_reg_write_data,"---------------------------------------------------------\n");  
+end
+
+always_ff @(posedge Clk ) begin
+    if(rv32i_ref.run && rv32i_ref.reg_wr_en) begin
+        $fwrite(trk_ref_reg_write_data,"%4h | %2d | %8h \n"
+        ,rv32i_ref.pc
+        ,rv32i_ref.rd
+        ,rv32i_ref.reg_wr_data
+        );
+    end
+end

--- a/verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh
+++ b/verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh
@@ -109,7 +109,7 @@ always @(posedge Clk) begin : memory_access_print
         else if(CRHitQ105H) begin
             $fwrite(trk_cr_data_memory_access,"%t | %8h | write |%8h |%8h \n", $realtime, PcQ105H, RegionMemAddrQ105H, RegionMemWrDataQ105H);
         end
-        else begin
+        begin//all writes to memory - no need for else
             $fwrite(trk_data_memory_access,"%t | %8h | write |%8h |%8h \n", $realtime, PcQ105H, RegionMemAddrQ105H, RegionMemWrDataQ105H);
         end 
     end
@@ -120,7 +120,7 @@ always @(posedge Clk) begin : memory_access_print
         else if(CRHitQ105H) begin
             $fwrite(trk_cr_data_memory_access,"%t | %8h | read  |%8h |%8h \n", $realtime, PcQ105H, RegionMemAddrQ105H, RegionMemRdDataQ105H);
         end
-        else begin
+        begin// all reads from memory - no need for else
             $fwrite(trk_data_memory_access,"%t | %8h | read  |%8h |%8h \n", $realtime, PcQ105H, RegionMemAddrQ105H, RegionMemRdDataQ105H);
         end
     end
@@ -192,4 +192,23 @@ always_ff @(posedge Clk ) begin
                            );
 end
 // FIXME
+
+integer trk_reg_write_data;
+initial begin: trk_reg_write_data_gen
+#1
+    trk_reg_write_data = $fopen({"../../../target/big_core_cachel1/tests/",test_name,"/trk_reg_write_data.log"},"w");
+    $fwrite(trk_reg_write_data,"---------------------------------------------------------\n");
+    $fwrite(trk_reg_write_data," PC | reg_dst | data \n");
+    $fwrite(trk_reg_write_data,"---------------------------------------------------------\n");  
+end
+
+always_ff @(posedge Clk ) begin
+    if(big_core_cachel1_top.big_core.big_core_rf.Ctrl.RegWrEnQ105H) begin
+        $fwrite(trk_reg_write_data,"%4h | %2d | %8h \n"
+        ,PcQ105H
+        ,big_core_cachel1_top.big_core.big_core_rf.Ctrl.RegDstQ105H
+        ,big_core_cachel1_top.big_core.big_core_rf.RegWrDataQ105H
+        );
+    end
+end
 

--- a/verif/rv32i_ref/tb/rv32i_ref.sv
+++ b/verif/rv32i_ref/tb/rv32i_ref.sv
@@ -103,7 +103,8 @@ assign debug_info.reg_wr_data = reg_wr_data;
 //=======================================================
 // DFF - the synchronous elements in the reference RV32I model
 //=======================================================
-`MAFIA_EN_DFF    (regfile, next_regfile,  clk, run);
+`MAFIA_EN_DFF    (regfile[0]   , '0                ,  clk, run);
+`MAFIA_EN_DFF    (regfile[31:1], next_regfile[31:1],  clk, run);
 `MAFIA_EN_DFF    (dmem,    next_dmem,     clk, run);
 `MAFIA_EN_DFF    (dmem_33, next_dmem_33,  clk, run);
 `MAFIA_EN_DFF    (imem,    next_imem,     clk, run);
@@ -563,7 +564,6 @@ always_comb begin
     end
     endcase
 
-    next_regfile[0] = '0; // x0 is always zero
 
 end// always_comb
 

--- a/verif/rv32i_ref/tb/rv32i_ref_tb.sv
+++ b/verif/rv32i_ref/tb/rv32i_ref_tb.sv
@@ -18,7 +18,7 @@
 `include "macros.vh"
 
 module rv32i_ref_tb;
-import common_pkg::*;
+import rv32i_ref_pkg::*;
 
 parameter I_MEM_OFFSET = 'h0_0000;
 parameter I_MEM_SIZE   = 'h1_0000; 

--- a/verif/rv32i_ref/tb/rv32i_ref_trk.vh
+++ b/verif/rv32i_ref/tb/rv32i_ref_trk.vh
@@ -1,5 +1,5 @@
 integer trk_ref_memory_access;
-initial begin: trk_rf_memory_access_gen
+initial begin: trk_ref_memory_access_gen
     #1
     trk_ref_memory_access = $fopen({"../../../target/rv32i_ref/tests/",test_name,"/trk_ref_memory_access.log"},"w");
     $fwrite(trk_ref_memory_access,"---------------------------------------------------------\n");
@@ -102,3 +102,25 @@ always_ff @(posedge Clk ) begin
                            );
 end
 
+
+
+// new tracker for all writes to the register file 
+// track PC, register destination, and the data written to the register
+integer trk_reg_write_data;
+
+initial begin: trk_reg_write_data_gen
+    trk_reg_write_data = $fopen({"../../../target/rv32i_ref/tests/",test_name,"/trk_reg_write_data_ref.log"},"w");
+    $fwrite(trk_reg_write_data,"---------------------------------------------------------\n");
+    $fwrite(trk_reg_write_data," PC | reg_dst | data \n");
+    $fwrite(trk_reg_write_data,"---------------------------------------------------------\n");  
+end
+
+always_ff @(posedge Clk ) begin
+    if(rv32i_ref.run) begin
+        $fwrite(trk_reg_write_data,"%4h | %2d | %8h \n"
+        ,rv32i_ref.pc
+        ,rv32i_ref.rd
+        ,rv32i_ref.regfile[rv32i_ref.rd]
+        );
+    end
+end


### PR DESCRIPTION
This pull request includes significant updates to the initialization and tracking mechanisms in the boot and verification files. The most important changes include restructuring the boot sequence, adding zero-initialization for sections, and introducing new tracking for register writes.

### Boot Sequence and Initialization:

* [`app/crt0/crt0_boot_trap.s`](diffhunk://#diff-3fc6e41e52b853f83b83b07b71feadae1f49a434a8be85e44a216581006f8578L11-R11): Moved the initialization code to a new `init_handler` and added zero-initialization loops for `.sbss` and `.bss` sections. [[1]](diffhunk://#diff-3fc6e41e52b853f83b83b07b71feadae1f49a434a8be85e44a216581006f8578L11-R11) [[2]](diffhunk://#diff-3fc6e41e52b853f83b83b07b71feadae1f49a434a8be85e44a216581006f8578R92-R175)
* [`app/crt0/crt0_default.s`](diffhunk://#diff-f29cc28acff658599b09ce8ec96e40f4804c6a8fd6a80b69855cc983fcb8be8bR9-R11): Added zero-initialization loops for `.sbss` and `.bss` sections in the `reset_handler`. [[1]](diffhunk://#diff-f29cc28acff658599b09ce8ec96e40f4804c6a8fd6a80b69855cc983fcb8be8bR9-R11) [[2]](diffhunk://#diff-f29cc28acff658599b09ce8ec96e40f4804c6a8fd6a80b69855cc983fcb8be8bL41-R71)

### Memory Layout:

* [`app/link.common.ld`](diffhunk://#diff-9f1efbd99d3225a10d13b0076196ac040ca0ec5d7daa670ad30586014794487fL6-R46): Updated the linker script to define and zero-initialize `.sbss` and `.bss` sections.

### Verification and Tracking:

* [`verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh`](diffhunk://#diff-92540facb52f70852532778b84b772910ca5bbc74c817a4992a97c101c285fa4L112-R112): Added new trackers for register writes, logging PC, register destination, and data. [[1]](diffhunk://#diff-92540facb52f70852532778b84b772910ca5bbc74c817a4992a97c101c285fa4L112-R112) [[2]](diffhunk://#diff-92540facb52f70852532778b84b772910ca5bbc74c817a4992a97c101c285fa4L123-R123) [[3]](diffhunk://#diff-92540facb52f70852532778b84b772910ca5bbc74c817a4992a97c101c285fa4R196-R214)
* [`verif/rv32i_ref/tb/rv32i_ref_trk.vh`](diffhunk://#diff-b84f1f5edb8a937e5a2630322e786923fe41bc50b89991af30d3eacf621057abL2-R2): Introduced a new tracker for register writes in the reference model. [[1]](diffhunk://#diff-b84f1f5edb8a937e5a2630322e786923fe41bc50b89991af30d3eacf621057abL2-R2) [[2]](diffhunk://#diff-b84f1f5edb8a937e5a2630322e786923fe41bc50b89991af30d3eacf621057abR105-R126)

### Miscellaneous:

* [`verif/rv32i_ref/tb/rv32i_ref.sv`](diffhunk://#diff-8332fb9291c48d742c277084c77754a3ae23e0aa366b8b722a4c466ba76f3366L106-R107): Modified DFF assignments to ensure `x0` is always zero. [[1]](diffhunk://#diff-8332fb9291c48d742c277084c77754a3ae23e0aa366b8b722a4c466ba76f3366L106-R107) [[2]](diffhunk://#diff-8332fb9291c48d742c277084c77754a3ae23e0aa366b8b722a4c466ba76f3366L566)
* [`verif/rv32i_ref/tb/rv32i_ref_tb.sv`](diffhunk://#diff-c3a919379c3d9cd33cb6aa4cca6a597c9d42ea539d8f5008849d2743c7e8eb17L21-R21): Updated the package import to `rv32i_ref_pkg`.