### PR TITLE
Fix the vga_alive with cache DUT

### DIFF
--- a/source/big_core/big_core_top.sv
+++ b/source/big_core/big_core_top.sv
@@ -83,7 +83,7 @@ big_core_mem_wrap big_core_mem_wrap(
 // //      core interface
 // //============================================
 // i_mem
- .ReadyQ101H            (ReadyQ101H), // input logic        ReadyQ101H,          // To I_MEM
+ .ReadyQ101H            (ReadyQ101H),          // input logic        ReadyQ101H,          // To I_MEM
  .PcQ100H               (PcQ100H),             //input  logic [31:0] PcQ100H,        //curr_pc    ,
  .PreInstructionQ101H   (PreInstructionQ101H), //output logic [31:0] PreInstructionQ101H, //instruction,
 // d_mem
@@ -93,7 +93,7 @@ big_core_mem_wrap big_core_mem_wrap(
  .DMemWrEnQ103H         (DMemWrEnQ103H),       // input  logic        DMemWrEnQ103H,       // To D_MEM
  .DMemRdEnQ103H         (DMemRdEnQ103H),       // input  logic        DMemRdEnQ103H,       // To D_MEM
  .DMemRdRspQ105H        (DMemRdRspQ105H),      // output logic [31:0] DMemRdRspQ105H       // From D_MEM
- .DMemReady        (DMemReady),      // output logic        DMemReady  , // From D_MEM
+ .DMemReady             (DMemReady),           // output logic        DMemReady  , // From D_MEM
 //============================================
 //      fabric interface
 //============================================

--- a/source/big_core_cachel1/big_core_cachel1_top.sv
+++ b/source/big_core_cachel1/big_core_cachel1_top.sv
@@ -62,11 +62,11 @@ big_core (
    .Rst                 ( Rst                ), // input  logic        Rst,
    .RstPc               ( RstPc              ), // input  logic        RstPc,
    // Instruction Memory
-   .ReadyQ101H          ( ReadyQ101H    ), // output logic        ReadyQ101H,          // To I_MEM
+   .ReadyQ101H          ( ReadyQ101H         ), // output logic        ReadyQ101H,          // To I_MEM
    .PcQ100H             ( PcQ100H            ), // output logic [31:0] PcQ100H,             // To I_MEM
    .PreInstructionQ101H ( PreInstructionQ101H), // input  logic [31:0] PreInstructionQ101H, // From I_MEM
    // Data Memory
-   .DMemReady           ( DMemReady     ), // input  logic        DMemReady  , // From D_MEM
+   .DMemReady           ( DMemReady          ), // input  logic        DMemReady  , // From D_MEM
    .Core2DmemReqQ103H   ( Core2DmemReqQ103H  ), // output logic [31:0] DMemWrDataQ103H,     // To D_MEM
    .DMemRdRspQ105H      ( DMemRdRspQ105H     )  // input  logic [31:0] DMemRdRspQ105H       // From D_MEM
 );

--- a/verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh
+++ b/verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh
@@ -68,9 +68,7 @@ logic CRHitQ104H, CRHitQ105H;
 logic [31:0] RegionMemRdDataQ105H;
 logic [31:0] RegionMemRdEnQ104H, RegionMemRdEnQ105H;
 assign RegionMemRdDataQ105H  = big_core_cachel1_top.big_core.big_core_wb.PostSxDMemRdDataQ105H;  // data read from memorry in case of MemRdEn
-`MAFIA_DFF(RegionMemRdEnQ104H, big_core_cachel1_top.big_core.big_core_mem_access1.Ctrl.DMemRdEnQ103H , Clk)
-`MAFIA_DFF(RegionMemRdEnQ105H, RegionMemRdEnQ104H , Clk)
-
+assign RegionMemRdEnQ105H = big_core_cachel1_top.big_core.big_core_ctrl.CtrlQ105H.RegWrEn && big_core_cachel1_top.big_core.big_core_ctrl.CtrlQ105H.e_SelWrBack == WB_DMEM;
 
 integer trk_data_memory_access;
 initial begin: trk_data_memory_access_gen


### PR DESCRIPTION
This pull request includes several changes to the `big_core_cachel1` testbench and tracking files to fix memory handling and fix the codebase.

Memory handling fix:

* [`verif/big_core_cachel1/tb/big_core_cachel1_tb.sv`](diffhunk://#diff-4afa7904c750d33b0707f99d23a438ce68db9b4143023c938afcab1be81870d9R36): Introduced a new temporary data memory array `TempDMem` to facilitate backdoor memory loading and forcing operations. This change ensures that `TempDMem` is used for loading and forcing operations, and then its contents are assigned to `DMem`. [[1]](diffhunk://#diff-4afa7904c750d33b0707f99d23a438ce68db9b4143023c938afcab1be81870d9R36) [[2]](diffhunk://#diff-4afa7904c750d33b0707f99d23a438ce68db9b4143023c938afcab1be81870d9L105-R113)
* [`verif/big_core_cachel1/tb/big_core_cachel1_tb.sv`](diffhunk://#diff-4afa7904c750d33b0707f99d23a438ce68db9b4143023c938afcab1be81870d9R246): Added assignment to `NextDMem` from `DMem` to ensure consistency in memory writes.

Codebase fixing the Verification:

* [`verif/big_core_cachel1/tb/big_core_cachel1_tb.sv`](diffhunk://#diff-4afa7904c750d33b0707f99d23a438ce68db9b4143023c938afcab1be81870d9L265-R272): Replaced `MAFIA_DFF` macros with direct assignments for sampling `cache2fm_req_q3` address and valid signals, to align correctly the access to far memory. (fixed the bug)
* [`verif/big_core_cachel1/tb/trk/big_core_cachel1_trk.vh`](diffhunk://#diff-92540facb52f70852532778b84b772910ca5bbc74c817a4992a97c101c285fa4L71-R71): Replaced `MAFIA_DFF` macros with direct assignments for `RegionMemRdEnQ105H`, fixing the alignment for the tracker